### PR TITLE
Add reasoning selector tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@ ReasonSuite MCP is a Model Context Protocol (MCP) server that bundles a planning
 ## Highlights
 
 - **Router-led planning.** The `reasoning.router.plan` tool picks a sequence of reasoning modes (dialectic, Socratic, abductive, systems, red/blue, analogical, constraint, razors) with arguments and rationale, falling back to a deterministic plan if sampling is unavailable.
-- **Seven reasoning tools.** Dialectic, Socratic, abductive, systems thinking, red/blue challenge, analogical mapping, and constraint solving are all exposed as MCP tools and return strict JSON payloads suitable for downstream automation.
+- **Comprehensive reasoning tools.** Dialectic, Socratic, abductive, systems thinking, red/blue challenge, analogical mapping, constraint solving, divergent/convergent synthesis, self-explanation, and the exec sandbox are all exposed as MCP tools that return strict JSON payloads.
+- **Meta selection helper.** A prompt-agnostic `reasoning.selector` tool inspects any request and recommends the next reasoning mode plus the most relevant Occam/Popper-style razors.
 - **Occam & falsifiability razors.** A dedicated `razors.apply` tool scores candidate explanations using MDL/Occam, Bayesian Occam, Sagan, Hitchens, Hanlon, and Popper heuristics.
 - **Prompt templates.** Matching MCP prompts are registered for each tool family so clients can opt into template-driven prompting instead of direct tool calls.
 - **Embedded resources.** Quick references (razors, systems thinking cheatsheet, constraint DSL) are published via MCP resources for in-client lookup.
@@ -63,6 +64,7 @@ After the server starts, connect with your MCP client, list the available tools/
 | Tool ID | Description |
 | --- | --- |
 | `reasoning.router.plan` | Plan a sequence of reasoning modes with arguments and rationale, with a safe fallback when sampling is unavailable. |
+| `reasoning.selector` | Recommend the most suitable reasoning mode plus supporting razors for a given request. |
 | `dialectic.tas` | Produce thesis, antithesis, synthesis, and open questions for a claim. |
 | `socratic.inquire` | Generate multi-layer Socratic question trees plus assumptions, evidence, and next actions. |
 | `abductive.hypothesize` | Generate and score candidate hypotheses, optionally applying razors. |

--- a/src/lib/prompt.ts
+++ b/src/lib/prompt.ts
@@ -1,0 +1,7 @@
+import type { ZodOptional, ZodTypeAny } from "zod";
+
+export type PromptArgsShape = Record<string, ZodTypeAny | ZodOptional<ZodTypeAny>>;
+
+export function definePromptArgsShape<T extends PromptArgsShape>(shape: T): T {
+    return shape;
+}

--- a/src/lib/razors.ts
+++ b/src/lib/razors.ts
@@ -1,0 +1,20 @@
+export const DEFAULT_RAZORS = ["MDL", "BayesianOccam", "Sagan", "Hitchens", "Hanlon", "Popper"] as const;
+
+export const RAZOR_DESCRIPTIONS: Record<string, string> = {
+    MDL: "Favor explanations with the minimal description length / simplest model consistent with the observations.",
+    BayesianOccam: "Prefer hypotheses that make sharper predictions with higher posterior odds when evidence is scarce.",
+    Sagan: "Extraordinary claims require proportionally extraordinary evidence; downgrade bold claims lacking support.",
+    Hitchens: "What can be asserted without evidence can be dismissed without evidence; demand explicit backing for key steps.",
+    Hanlon: "Do not attribute to malice what can be explained by neglect, noise, or incompetence.",
+    Popper: "Retain hypotheses that are falsifiable with clear tests; discard unfalsifiable stories.",
+};
+
+export function summarizeRazors(names: string[]): string {
+    if (!names.length) return "None";
+    return names
+        .map((name) => {
+            const desc = RAZOR_DESCRIPTIONS[name] ?? "";
+            return desc ? `${name}: ${desc}` : name;
+        })
+        .join("\n");
+}

--- a/src/lib/structured.ts
+++ b/src/lib/structured.ts
@@ -1,0 +1,131 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+
+type FallbackValue<T> = T | (() => T);
+
+type SampleStructuredOptions<T> = {
+    server: McpServer;
+    prompt: string;
+    maxTokens: number;
+    schema: z.ZodType<T>;
+    fallback: FallbackValue<T>;
+};
+
+export const ReasoningMetadataSchema = z.object({
+    source: z.enum(["model", "fallback"]),
+    warnings: z.array(z.string()).default([]),
+    raw: z.string().optional(),
+});
+
+type ReasoningMetadata = z.infer<typeof ReasoningMetadataSchema>;
+
+function resolveFallback<T>(fallback: FallbackValue<T>): T {
+    return typeof fallback === "function" ? (fallback as () => T)() : fallback;
+}
+
+function clonePayload<T>(value: T): T {
+    if (typeof globalThis.structuredClone === "function") {
+        return structuredClone(value);
+    }
+    return JSON.parse(JSON.stringify(value));
+}
+
+function attachMeta<T>(payload: T, meta: ReasoningMetadata): T {
+    const cloned: any = clonePayload(payload ?? {});
+    const existing = cloned?.meta ?? {};
+    const warnings = Array.from(
+        new Set([...(existing.warnings ?? []), ...(meta.warnings ?? [])].filter((w): w is string => typeof w === "string"))
+    );
+    cloned.meta = { ...existing, ...meta, warnings };
+    if (!cloned.meta.raw) {
+        delete cloned.meta.raw;
+    }
+    if (!cloned.meta.warnings?.length) {
+        delete cloned.meta.warnings;
+    }
+    return cloned;
+}
+
+function buildCandidates(raw: string): string[] {
+    const trimmed = raw.trim();
+    const candidates = new Set<string>();
+    if (!trimmed) {
+        return [];
+    }
+    candidates.add(trimmed);
+    const fenced = /```(?:json)?\s*([\s\S]*?)```/i.exec(trimmed);
+    if (fenced?.[1]) {
+        candidates.add(fenced[1].trim());
+    }
+    const firstBrace = trimmed.indexOf("{");
+    const lastBrace = trimmed.lastIndexOf("}");
+    if (firstBrace !== -1 && lastBrace !== -1 && lastBrace > firstBrace) {
+        candidates.add(trimmed.slice(firstBrace, lastBrace + 1).trim());
+    }
+    const firstBracket = trimmed.indexOf("[");
+    const lastBracket = trimmed.lastIndexOf("]");
+    if (firstBracket !== -1 && lastBracket !== -1 && lastBracket > firstBracket) {
+        candidates.add(trimmed.slice(firstBracket, lastBracket + 1).trim());
+    }
+    return Array.from(candidates.values()).filter((candidate) => candidate.length > 0);
+}
+
+function tryParse(candidate: string) {
+    try {
+        return { success: true as const, value: JSON.parse(candidate) };
+    } catch (err: any) {
+        return { success: false as const, error: err?.message ?? String(err) };
+    }
+}
+
+export async function sampleStructuredJson<T>({ server, prompt, maxTokens, schema, fallback }: SampleStructuredOptions<T>) {
+    const warnings: string[] = [];
+    let raw = "";
+
+    try {
+        const response = await server.server.createMessage({
+            messages: [{ role: "user", content: { type: "text", text: prompt } }],
+            maxTokens,
+        });
+        const content: any = (response as any)?.content;
+        if (content && typeof content?.text === "string") {
+            raw = content.text;
+        } else if (Array.isArray(content)) {
+            const textPart = content.find((part: any) => typeof part?.text === "string");
+            raw = textPart?.text ?? "";
+        } else {
+            warnings.push("LLM response did not include text content.");
+        }
+    } catch (err: any) {
+        warnings.push(`LLM sampling failed: ${err?.message ?? String(err)}`);
+    }
+
+    const candidates = buildCandidates(raw);
+    for (const candidate of candidates) {
+        const parsed = tryParse(candidate);
+        if (!parsed.success) {
+            warnings.push(`JSON parse error: ${parsed.error}`);
+            continue;
+        }
+        const validated = schema.safeParse(parsed.value);
+        if (validated.success) {
+            const data = attachMeta(validated.data, {
+                source: "model",
+                warnings,
+                raw: raw.trim() || undefined,
+            });
+            return { data, text: JSON.stringify(data, null, 2), usedFallback: false as const };
+        }
+        warnings.push(`Schema validation error: ${validated.error.message}`);
+    }
+
+    const fallbackValue = resolveFallback(fallback);
+    const data = attachMeta(fallbackValue, {
+        source: "fallback",
+        warnings: warnings.length ? warnings : ["Used deterministic fallback output."],
+        raw: raw.trim() || undefined,
+    });
+    return { data, text: JSON.stringify(data, null, 2), usedFallback: true as const };
+}
+
+export type SampleStructuredResult<T> = Awaited<ReturnType<typeof sampleStructuredJson<T>>>;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -6,10 +6,21 @@ export type ReasoningMode =
     | "redblue"
     | "analogical"
     | "constraint"
-    | "razors.apply";
+    | "razors.apply"
+    | "scientific"
+    | "self_explain"
+    | "divergent"
+    | "exec";
+
+export type ReasoningMetadata = {
+    source: "model" | "fallback";
+    warnings?: string[];
+    raw?: string;
+};
 
 export type RouterStep = {
     mode: ReasoningMode;
+    tool?: string;
     why: string;
     args?: Record<string, unknown>;
 };
@@ -17,6 +28,7 @@ export type RouterStep = {
 export type RouterPlan = {
     steps: RouterStep[];
     notes?: string;
+    meta?: ReasoningMetadata;
 };
 
 export type DialecticResult = {
@@ -29,6 +41,7 @@ export type DialecticResult = {
         evidence_needed: string[];
     };
     open_questions: string[];
+    meta?: ReasoningMetadata;
 };
 
 export type SocraticTree = {
@@ -36,6 +49,7 @@ export type SocraticTree = {
     assumptions_to_test: string[];
     evidence_to_collect: string[];
     next_actions: string[];
+    meta?: ReasoningMetadata;
 };
 
 export type AbductiveHypothesis = {
@@ -55,6 +69,7 @@ export type AbductiveResult = {
     hypotheses: AbductiveHypothesis[];
     experiments_or_evidence: string[];
     notes?: string;
+    meta?: ReasoningMetadata;
 };
 
 export type RazorsDecision = {
@@ -68,6 +83,7 @@ export type RazorsResult = {
     results: RazorsDecision[];
     shortlist: string[];
     notes?: string;
+    meta?: ReasoningMetadata;
 };
 
 export type SystemsMap = {
@@ -77,6 +93,7 @@ export type SystemsMap = {
     stock_flow_hints: { stock: string; inflows: string[]; outflows: string[] }[];
     assumptions: string[];
     risks: string[];
+    meta?: ReasoningMetadata;
 };
 
 export type RedBlueRound = {
@@ -90,6 +107,7 @@ export type RedBlueResult = {
     defects: { type: string; severity: "low" | "med" | "high"; evidence: string }[];
     risk_matrix: { low: string[]; medium: string[]; high: string[] };
     final_guidance: string[];
+    meta?: ReasoningMetadata;
 };
 
 export type AnalogicalResult = {
@@ -98,6 +116,15 @@ export type AnalogicalResult = {
     mismatches: string[];
     transferable_insights: string[];
     failure_modes: string[];
+    meta?: ReasoningMetadata;
 };
 
-
+export type ReasoningSelectorResult = {
+    primary_mode: { id: string; label: string; confidence: number; reason: string };
+    supporting_modes: { id: string; label: string; score: number; reason: string }[];
+    razor_stack: { id: string; label: string; score: number; reason: string }[];
+    decision_path: { observation: string; implication: string }[];
+    next_action?: string;
+    notes?: string;
+    meta?: ReasoningMetadata;
+};

--- a/src/prompts/abductive.ts
+++ b/src/prompts/abductive.ts
@@ -1,26 +1,34 @@
-import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { McpServer, PromptCallback } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
+import { definePromptArgsShape } from "../lib/prompt.js";
+
+const ArgsSchema = z.object({
+    observations: z.string(),
+    k: z.string().optional(),
+});
+
+const argsShape = definePromptArgsShape(ArgsSchema.shape);
 
 export function registerAbductivePrompts(server: McpServer): void {
+    const callback: PromptCallback<typeof argsShape> = ({ observations, k }, _extra) => ({
+        messages: [
+            {
+                role: "user",
+                content: {
+                    type: "text",
+                    text: `Observations:\n${observations}\nGenerate ${k ?? "4"} abductive hypotheses with scores (prior, power, simplicity_penalty (MDL proxy), testability) and overall. Output JSON.`,
+                },
+            },
+        ],
+    });
+
     server.registerPrompt(
         "abductive.hypotheses",
         {
             title: "Abductive Hypotheses",
             description: "k-best explanations with razors",
-            argsSchema: { observations: z.string(), k: z.string().optional() },
+            argsSchema: argsShape,
         },
-        ({ observations, k }) => ({
-            messages: [
-                {
-                    role: "user",
-                    content: {
-                        type: "text",
-                        text: `Observations:\n${observations}\nGenerate ${k ?? "4"} abductive hypotheses with scores (prior, power, simplicity_penalty (MDL proxy), testability) and overall. Output JSON.`,
-                    },
-                },
-            ],
-        })
+        callback
     );
 }
-
-

--- a/src/prompts/analogical.ts
+++ b/src/prompts/analogical.ts
@@ -1,26 +1,38 @@
-import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { McpServer, PromptCallback } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
+import { definePromptArgsShape } from "../lib/prompt.js";
+
+const ArgsSchema = z.object({
+    source_domain: z.string(),
+    target_problem: z.string(),
+    constraints: z.string().optional(),
+});
+
+const argsShape = definePromptArgsShape(ArgsSchema.shape);
 
 export function registerAnalogicalPrompts(server: McpServer): void {
+    const callback: PromptCallback<typeof argsShape> = (
+        { source_domain, target_problem, constraints },
+        _extra
+    ) => ({
+        messages: [
+            {
+                role: "user",
+                content: {
+                    type: "text",
+                    text: `Build a structural analogy from SOURCE to TARGET.\n\nSOURCE: ${source_domain}\nTARGET: ${target_problem}\nCONSTRAINTS: ${constraints ?? ""}\n\nReturn JSON mapping, shared_relations, mismatches, transferable_insights, failure_modes.`,
+                },
+            },
+        ],
+    });
+
     server.registerPrompt(
         "analogical.map",
         {
             title: "Analogical Mapping",
             description: "Map structure from source to target",
-            argsSchema: { source_domain: z.string(), target_problem: z.string(), constraints: z.string().optional() },
+            argsSchema: argsShape,
         },
-        ({ source_domain, target_problem, constraints }) => ({
-            messages: [
-                {
-                    role: "user",
-                    content: {
-                        type: "text",
-                        text: `Build a structural analogy from SOURCE to TARGET.\n\nSOURCE: ${source_domain}\nTARGET: ${target_problem}\nCONSTRAINTS: ${constraints ?? ""}\n\nReturn JSON mapping, shared_relations, mismatches, transferable_insights, failure_modes.`,
-                    },
-                },
-            ],
-        })
+        callback
     );
 }
-
-

--- a/src/prompts/constraint.ts
+++ b/src/prompts/constraint.ts
@@ -1,20 +1,33 @@
-import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { McpServer, PromptCallback } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
+import { definePromptArgsShape } from "../lib/prompt.js";
+
+const ArgsSchema = z.object({
+    model_json: z.string(),
+});
+
+const argsShape = definePromptArgsShape(ArgsSchema.shape);
 
 export function registerConstraintPrompts(server: McpServer): void {
+    const callback: PromptCallback<typeof argsShape> = ({ model_json }, _extra) => ({
+        messages: [
+            {
+                role: "user",
+                content: {
+                    type: "text",
+                    text: `Solve constraints using Z3.\nInput JSON: ${model_json}\nReturn JSON {"status":"sat|unsat|unknown","model":{...}}`,
+                },
+            },
+        ],
+    });
+
     server.registerPrompt(
         "constraint.solve",
         {
             title: "Constraint Solve",
             description: "Z3 mini-DSL JSON input",
-            argsSchema: { model_json: z.string() },
+            argsSchema: argsShape,
         },
-        ({ model_json }) => ({
-            messages: [
-                { role: "user", content: { type: "text", text: `Solve constraints using Z3.\nInput JSON: ${model_json}\nReturn JSON {"status":"sat|unsat|unknown","model":{...}}` } },
-            ],
-        })
+        callback
     );
 }
-
-

--- a/src/prompts/dialectic.ts
+++ b/src/prompts/dialectic.ts
@@ -1,30 +1,38 @@
-import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { McpServer, PromptCallback } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
+import { definePromptArgsShape } from "../lib/prompt.js";
+
+const ArgsSchema = z.object({
+    claim: z.string(),
+    context: z.string().optional(),
+});
+
+const argsShape = definePromptArgsShape(ArgsSchema.shape);
 
 export function registerDialecticPrompts(server: McpServer): void {
+    const callback: PromptCallback<typeof argsShape> = ({ claim, context }, _extra) => ({
+        messages: [
+            {
+                role: "user",
+                content: {
+                    type: "text",
+                    text: `Frame the following with a dialectic lens.
+Claim: ${claim}
+Context: ${context ?? ""}
+
+Output JSON with thesis, antithesis, synthesis (proposal, assumptions, tradeoffs, evidence_needed), open_questions.`,
+                },
+            },
+        ],
+    });
+
     server.registerPrompt(
         "dialectic.tas",
         {
             title: "Dialectic TAS",
             description: "Thesis–Antithesis–Synthesis template",
-            argsSchema: { claim: z.string(), context: z.string().optional() },
+            argsSchema: argsShape,
         },
-        ({ claim, context }) => ({
-            messages: [
-                {
-                    role: "user",
-                    content: {
-                        type: "text",
-                        text: `Frame the following with a dialectic lens.
-Claim: ${claim}
-Context: ${context ?? ""}
-
-Output JSON with thesis, antithesis, synthesis (proposal, assumptions, tradeoffs, evidence_needed), open_questions.`,
-                    },
-                },
-            ],
-        })
+        callback
     );
 }
-
-

--- a/src/prompts/divergent.ts
+++ b/src/prompts/divergent.ts
@@ -1,27 +1,35 @@
-import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { McpServer, PromptCallback } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
+import { definePromptArgsShape } from "../lib/prompt.js";
+
+const ArgsSchema = z.object({
+    prompt: z.string(),
+    k: z.string().optional(),
+    criteria: z.string().optional(),
+});
+
+const argsShape = definePromptArgsShape(ArgsSchema.shape);
 
 export function registerDivergentPrompts(server: McpServer): void {
+    const callback: PromptCallback<typeof argsShape> = ({ prompt, k, criteria }, _extra) => ({
+        messages: [
+            {
+                role: "user",
+                content: {
+                    type: "text",
+                    text: `Divergent (ideas) then Convergent (scoring).\nTask: ${prompt}\nK: ${k ?? "5"}\nCriteria: ${criteria ?? "novelty,consistency,relevance"}\nReturn JSON with divergent, scores, winner, synthesis.`,
+                },
+            },
+        ],
+    });
+
     server.registerPrompt(
         "reasoning.divergent_convergent",
         {
             title: "Divergent–Convergent",
             description: "Brainstorm then evaluate & synthesize",
-            argsSchema: { prompt: z.string(), k: z.string().optional(), criteria: z.string().optional() },
+            argsSchema: argsShape,
         },
-        ({ prompt, k, criteria }) => ({
-            messages: [
-                {
-                    role: "user",
-                    content: {
-                        type: "text",
-                        text: `Divergent (ideas) then Convergent (scoring).\nTask: ${prompt}\nK: ${k ?? "5"}\nCriteria: ${criteria ?? "novelty,consistency,relevance"}\nReturn JSON with divergent, scores, winner, synthesis.`,
-                    },
-                },
-            ],
-        })
+        callback
     );
 }
-
-
-

--- a/src/prompts/redblue.ts
+++ b/src/prompts/redblue.ts
@@ -1,30 +1,35 @@
-import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { McpServer, PromptCallback } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
+import { definePromptArgsShape } from "../lib/prompt.js";
+
+const ArgsSchema = z.object({
+    proposal: z.string(),
+    rounds: z.string().optional(),
+    focus: z.string().optional(),
+});
+
+const argsShape = definePromptArgsShape(ArgsSchema.shape);
 
 export function registerRedBluePrompts(server: McpServer): void {
+    const callback: PromptCallback<typeof argsShape> = ({ proposal, rounds, focus }, _extra) => ({
+        messages: [
+            {
+                role: "user",
+                content: {
+                    type: "text",
+                    text: `Conduct ${rounds ?? "2"} rounds of Red (attack) vs Blue (defense) on:\n${proposal}\n\nFocus areas: ${focus ?? "safety,bias,hallucination,security,privacy"}. Return JSON transcript, defects, risk_matrix, final_guidance.`,
+                },
+            },
+        ],
+    });
+
     server.registerPrompt(
         "redblue.challenge",
         {
             title: "Red/Blue Challenge",
             description: "Adversarial critique with risk matrix",
-            argsSchema: {
-                proposal: z.string(),
-                rounds: z.string().optional(),
-                focus: z.string().optional(),
-            },
+            argsSchema: argsShape,
         },
-        ({ proposal, rounds, focus }) => ({
-            messages: [
-                {
-                    role: "user",
-                    content: {
-                        type: "text",
-                        text: `Conduct ${rounds ?? "2"} rounds of Red (attack) vs Blue (defense) on:\n${proposal}\n\nFocus areas: ${focus ?? "safety,bias,hallucination,security,privacy"}. Return JSON transcript, defects, risk_matrix, final_guidance.`,
-                    },
-                },
-            ],
-        })
+        callback
     );
 }
-
-

--- a/src/prompts/scientific.ts
+++ b/src/prompts/scientific.ts
@@ -1,27 +1,35 @@
-import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { McpServer, PromptCallback } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
+import { definePromptArgsShape } from "../lib/prompt.js";
+
+const ArgsSchema = z.object({
+    goal: z.string(),
+    context: z.string().optional(),
+    allow_tools: z.string().optional(),
+});
+
+const argsShape = definePromptArgsShape(ArgsSchema.shape);
 
 export function registerScientificPrompts(server: McpServer): void {
+    const callback: PromptCallback<typeof argsShape> = ({ goal, context, allow_tools }, _extra) => ({
+        messages: [
+            {
+                role: "user",
+                content: {
+                    type: "text",
+                    text: `You are an agent following a Scientific Analytic Framework.\nGoal: ${goal}\nContext: ${context ?? ""}\nAllow tools: ${allow_tools ?? "true"}\nReturn JSON with decomposition, hypotheses, tests, verification, answer.`,
+                },
+            },
+        ],
+    });
+
     server.registerPrompt(
         "reasoning.scientific",
         {
             title: "Scientific Analytic",
             description: "Decompose → hypothesize → test → verify",
-            argsSchema: { goal: z.string(), context: z.string().optional(), allow_tools: z.string().optional() },
+            argsSchema: argsShape,
         },
-        ({ goal, context, allow_tools }) => ({
-            messages: [
-                {
-                    role: "user",
-                    content: {
-                        type: "text",
-                        text: `You are an agent following a Scientific Analytic Framework.\nGoal: ${goal}\nContext: ${context ?? ""}\nAllow tools: ${allow_tools ?? "true"}\nReturn JSON with decomposition, hypotheses, tests, verification, answer.`,
-                    },
-                },
-            ],
-        })
+        callback
     );
 }
-
-
-

--- a/src/prompts/self_explain.ts
+++ b/src/prompts/self_explain.ts
@@ -1,27 +1,34 @@
-import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { McpServer, PromptCallback } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
+import { definePromptArgsShape } from "../lib/prompt.js";
+
+const ArgsSchema = z.object({
+    query: z.string(),
+    allow_citations: z.string().optional(),
+});
+
+const argsShape = definePromptArgsShape(ArgsSchema.shape);
 
 export function registerSelfExplainPrompts(server: McpServer): void {
+    const callback: PromptCallback<typeof argsShape> = ({ query, allow_citations }, _extra) => ({
+        messages: [
+            {
+                role: "user",
+                content: {
+                    type: "text",
+                    text: `Transparent Self-Explanation for: ${query}\nCitations allowed: ${allow_citations ?? "true"}\nReturn JSON with rationale, evidence, self_critique, revision.`,
+                },
+            },
+        ],
+    });
+
     server.registerPrompt(
         "reasoning.self_explain",
         {
             title: "Self-Explanation",
             description: "Rationale + evidence + critique + revision",
-            argsSchema: { query: z.string(), allow_citations: z.string().optional() },
+            argsSchema: argsShape,
         },
-        ({ query, allow_citations }) => ({
-            messages: [
-                {
-                    role: "user",
-                    content: {
-                        type: "text",
-                        text: `Transparent Self-Explanation for: ${query}\nCitations allowed: ${allow_citations ?? "true"}\nReturn JSON with rationale, evidence, self_critique, revision.`,
-                    },
-                },
-            ],
-        })
+        callback
     );
 }
-
-
-

--- a/src/prompts/socratic.ts
+++ b/src/prompts/socratic.ts
@@ -1,27 +1,35 @@
-import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { McpServer, PromptCallback } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
+import { definePromptArgsShape } from "../lib/prompt.js";
+
+const ArgsSchema = z.object({
+    topic: z.string(),
+    depth: z.string().optional(),
+});
+
+const argsShape = definePromptArgsShape(ArgsSchema.shape);
 
 export function registerSocraticPrompts(server: McpServer): void {
+    const callback: PromptCallback<typeof argsShape> = ({ topic, depth }, _extra) => ({
+        messages: [
+            {
+                role: "user",
+                content: {
+                    type: "text",
+                    text: `Produce a ${depth ?? "3"}-layer Socratic question tree for: ${topic}
+Include assumptions_to_test, evidence_to_collect, next_actions. Output JSON.`,
+                },
+            },
+        ],
+    });
+
     server.registerPrompt(
         "socratic.tree",
         {
             title: "Socratic Tree",
             description: "Generate multi-layer probing questions + assumptions/evidence",
-            argsSchema: { topic: z.string(), depth: z.string().optional() },
+            argsSchema: argsShape,
         },
-        ({ topic, depth }) => ({
-            messages: [
-                {
-                    role: "user",
-                    content: {
-                        type: "text",
-                        text: `Produce a ${depth ?? "3"}-layer Socratic question tree for: ${topic}
-Include assumptions_to_test, evidence_to_collect, next_actions. Output JSON.`,
-                    },
-                },
-            ],
-        })
+        callback
     );
 }
-
-

--- a/src/prompts/systems.ts
+++ b/src/prompts/systems.ts
@@ -1,30 +1,34 @@
-import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { McpServer, PromptCallback } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
+import { definePromptArgsShape } from "../lib/prompt.js";
+
+const ArgsSchema = z.object({
+    variables: z.string().optional(),
+    context: z.string().optional(),
+});
+
+const argsShape = definePromptArgsShape(ArgsSchema.shape);
 
 export function registerSystemsPrompts(server: McpServer): void {
+    const callback: PromptCallback<typeof argsShape> = ({ variables, context }, _extra) => ({
+        messages: [
+            {
+                role: "user",
+                content: {
+                    type: "text",
+                    text: `Build a concise causal loop diagram (CLD) for the system below.\nVariables: ${variables ?? ""}\nContext: ${context ?? ""}\n\nReturn JSON: { "mermaid": "...", "loops": [...], "leverage_points": [...], "stock_flow_hints": [...], "assumptions": [...], "risks": [...] }`,
+                },
+            },
+        ],
+    });
+
     server.registerPrompt(
         "systems.map",
         {
             title: "Systems Map (CLD)",
             description: "Mermaid CLD + loops + leverage points",
-            argsSchema: { variables: z.string().optional(), context: z.string().optional() },
+            argsSchema: argsShape,
         },
-        ({ variables, context }) => ({
-            messages: [
-                {
-                    role: "user",
-                    content: {
-                        type: "text",
-                        text: `Build a concise causal loop diagram (CLD) for the system below.
-Variables: ${variables ?? ""}
-Context: ${context ?? ""}
-
-Return JSON: { "mermaid": "...", "loops": [...], "leverage_points": [...], "stock_flow_hints": [...], "assumptions": [...], "risks": [...] }`,
-                    },
-                },
-            ],
-        })
+        callback
     );
 }
-
-

--- a/src/resources/constraint-dsl.md
+++ b/src/resources/constraint-dsl.md
@@ -1,1 +1,105 @@
-Constraint DSL — placeholder. See README for details.
+# Constraint Mini-DSL
+
+The ReasonSuite constraint tool consumes JSON that describes decision variables, hard constraints, and an optional optimisation objective. The JSON is validated with Zod, translated to SMT-LIB, and solved with Z3. This guide explains how to structure requests and includes idiomatic patterns for common scenarios.
+
+## Top-level structure
+
+```json
+{
+  "variables": [{ "name": "x", "type": "Int" }],
+  "constraints": ["(>= x 0)", "(<= x 10)"],
+  "optimize": { "objective": "x", "sense": "max" }
+}
+```
+
+| Field | Description |
+| --- | --- |
+| `variables` | Array of variable declarations. Each entry must specify a `name` (letters/underscores) and a `type`: `Int`, `Real`, or `Bool`. |
+| `constraints` | Array of SMT-LIB expressions written as strings. Each expression is wrapped in `(assert …)` before being sent to Z3. Leave empty to solve a purely optimisation problem. |
+| `optimize` | Optional optimisation directive. `objective` is any SMT-LIB expression. `sense` accepts `"min"` or `"max"`. When omitted the solver returns any satisfying model. |
+
+## Declaring variables
+
+- Use descriptive names: `inventory`, `throughput`, `is_enabled`.
+- Integers (`Int`) are appropriate for counts or enumerations; use `Real` for continuous values; use `Bool` for logical flags.
+- Duplicate names are rejected.
+
+Examples:
+
+```json
+{
+  "variables": [
+    { "name": "units", "type": "Int" },
+    { "name": "cost", "type": "Real" },
+    { "name": "feature_enabled", "type": "Bool" }
+  ]
+}
+```
+
+## Writing constraints
+
+Constraints are plain SMT-LIB snippets. The tool automatically wraps each string with `(assert …)` so you only need the inner expression. Useful combinators:
+
+- `(= a b)` equality
+- `(>= a b)`, `(<= a b)` inequalities
+- `(and …)`, `(or …)`, `(not …)` logical composition
+- `(+ …)`, `(- …)`, `(* …)`, `(/ …)` arithmetic
+- `(ite condition then else)` for conditional expressions
+
+Example — simple scheduling constraints:
+
+```json
+{
+  "variables": [
+    { "name": "hours_engineering", "type": "Int" },
+    { "name": "hours_design", "type": "Int" }
+  ],
+  "constraints": [
+    "(>= hours_engineering 0)",
+    "(>= hours_design 0)",
+    "(= (+ hours_engineering hours_design) 40)",
+    "(>= hours_engineering 10)",
+    "(>= hours_design 8)"
+  ]
+}
+```
+
+## Optimisation
+
+When `optimize` is supplied, the tool switches to Z3's `Optimize` mode. For minimisation use `"sense": "min"`; for maximisation use `"sense": "max"`.
+
+```json
+{
+  "variables": [
+    { "name": "x", "type": "Int" },
+    { "name": "y", "type": "Int" }
+  ],
+  "constraints": [
+    "(>= x 0)",
+    "(>= y 0)",
+    "(= (+ x y) 10)"
+  ],
+  "optimize": {
+    "objective": "(+ (* 2 x) y)",
+    "sense": "max"
+  }
+}
+```
+
+If the optimisation problem is infeasible (`unsat` or `unknown`), the response still includes the solver status.
+
+## Tips and troubleshooting
+
+- **Validate incrementally.** Start with a small subset of constraints; add more as the solver returns `sat` to isolate mistakes.
+- **Watch types.** Mixing `Int` and `Real` automatically coerces integers to reals. Use `to_int`/`to_real` when required.
+- **Boolean flags.** Encode logical relations using `Bool` variables and `=>` implications (e.g., `(=> feature_enabled (>= throughput 100))`).
+- **Piecewise objectives.** Use `(ite …)` within the `objective` to encode conditional scoring.
+- **Debugging unsat.** Temporarily remove `optimize` and inspect the reported model; if still `unsat`, relax constraints until the solver returns a model, then reintroduce tightened conditions one at a time.
+
+## Suggested workflow
+
+1. List the decision variables and mark their domains.
+2. Translate each requirement into SMT-LIB expressions. The Socratic or Scientific tools can help enumerate assumptions first.
+3. Add optional optimisation criteria once feasibility is confirmed.
+4. Run `constraint.solve` and inspect the resulting `model` for assignments.
+5. Pair with `razors.apply` or `redblue.challenge` to stress-test assumptions or compare alternative formulations.

--- a/src/resources/razors.md
+++ b/src/resources/razors.md
@@ -1,1 +1,41 @@
-Reasoning Razors — placeholder. See README for details.
+# Reasoning Razors
+
+Use these heuristics to prune weak explanations, challenge extraordinary claims, and focus investigation time on the options most likely to survive scrutiny. The `razors.apply` tool and several ReasonSuite prompts reference the guidance below.
+
+## MDL / Occam's Razor
+- Prefer hypotheses with the **Minimum Description Length**: the shortest combined encoding of the model plus the data when the model is true.
+- Penalise gratuitous entities, parameters, or branching logic that do not improve predictive power.
+- When comparing explanations, subtract a *simplicity penalty* from otherwise strong candidates.
+
+## Bayesian Occam's Razor
+- In Bayesian reasoning, complex hypotheses distribute probability mass across a larger outcome space, reducing posterior odds unless supported by strong evidence.
+- Downweight stories that require many precise coincidences to remain plausible.
+- Reward hypotheses that make sharp, testable predictions.
+
+## Sagan Standard
+- "Extraordinary claims require extraordinary evidence." Elevate the evidence bar when a proposal overturns well-supported priors or implies high-impact consequences.
+- Ask: *What observations would persuade a sceptical but informed reviewer?* If such evidence is missing, the claim should be deferred or reframed.
+
+## Hitchens's Razor
+- "What can be asserted without evidence can be dismissed without evidence."
+- Require explicit citations, data, or derivations for every major step in a chain of reasoning.
+- Flag bare assertions for follow-up fact-finding rather than treating them as premises.
+
+## Hanlon's Razor
+- "Never attribute to malice that which is adequately explained by neglect or incompetence."
+- When diagnosing failures or incidents, inspect mundane causes (misconfigurations, missing process, noisy data) before invoking adversarial intent.
+- Combine with the red/blue tool to check whether adversarial scenarios still matter after simpler explanations are exhausted.
+
+## Popper's Falsifiability Principle
+- Prefer hypotheses that expose themselves to clear refutation.
+- Record the *critical tests* or experiments that would falsify each claim.
+- Treat unfalsifiable or overly vague narratives as high risk: they cannot be improved by feedback loops and often mask confirmation bias.
+
+## Practical checklist
+
+1. **List candidates.** Use Socratic or Abductive tools to enumerate explanations, then feed the JSON directly into `razors.apply`.
+2. **Score with razors.** For each candidate note which razor(s) triggered and why. Keep a shortlist of the survivors.
+3. **Design tests.** Hand the shortlist to `reasoning.scientific` or the constraint solver to design falsification attempts.
+4. **Challenge before commitment.** Run `redblue.challenge` to probe for failure modes, then revise or drop weak options.
+
+Documenting which razor eliminated an option builds a reusable knowledge trail and prevents teams from cycling through the same weak hypotheses in future investigations.

--- a/src/resources/systems-cheatsheet.md
+++ b/src/resources/systems-cheatsheet.md
@@ -1,1 +1,53 @@
-Systems Thinking Cheatsheet — placeholder. See README for details.
+# Systems Thinking Cheatsheet
+
+Use this reference when constructing causal loop diagrams (CLDs) or interpreting the output of the `systems.map` tool.
+
+## Core concepts
+
+- **Variables:** Elements whose levels change over time (e.g., demand, backlog, user trust). Stick to nouns or short noun phrases.
+- **Links:** Directed arrows annotated with `+` (same-direction change) or `–` (opposite-direction change). A `+` link means if the source increases, the target eventually increases relative to its prior trajectory.
+- **Delays:** Mark with `||` or a dotted line to show lagged effects.
+- **Reinforcing loop (R):** Feedback that amplifies change. Example: word-of-mouth growth → more users → more word-of-mouth.
+- **Balancing loop (B):** Feedback that counteracts change and drives the system toward a goal. Example: inventory → shipments → lower backlog → fewer rush orders → stabilised inventory.
+
+## Building a CLD
+
+1. **List the stocks and flows.** Stocks accumulate (inventory, knowledge, debt); flows increase or decrease them.
+2. **Capture obvious loops.** For each loop determine whether it is reinforcing (R) or balancing (B).
+3. **Highlight leverage points.** Ask where a small intervention yields a large effect: information flows, delays, buffers, rules, goals, or paradigms.
+4. **Document assumptions and risks.** Note missing actors, policy constraints, or data that would validate the loop structure.
+
+## Common leverage points (Meadows, 1999)
+
+| Category | Example intervention |
+| --- | --- |
+| Parameters | Adjust thresholds, capacities, or budgets |
+| Buffers | Increase slack time or spare inventory |
+| Information flows | Improve telemetry, transparency, or feedback cadence |
+| Rules/incentives | Change governance, KPIs, or escalation paths |
+| Self-organisation | Enable local teams to adapt processes |
+| Goals | Shift success metrics to align with long-term outcomes |
+| Paradigms | Reframe mission, values, or mental models |
+
+## Stock/flow patterns to consider
+
+- **Bathtub structure:** Stock increases with inflow and decreases with outflow (e.g., backlog). Useful to check conservation and units.
+- **Success to the successful:** Reinforcing loop that diverts resources toward already successful actors, starving others.
+- **Limits to growth:** Reinforcing loop plus a slower balancing loop that introduces constraints (capacity, fatigue, regulation).
+- **Shifting the burden:** Quick fixes relieve symptoms while weakening the capability to address root causes.
+
+## Integrating with other tools
+
+- After mapping loops, feed candidate leverage interventions into `abductive.hypothesize` or `reasoning.divergent_convergent` for option generation.
+- Use `razors.apply` to drop interventions that require brittle assumptions or violate MDL.
+- Combine with `constraint.solve` to test quantitative feasibility of proposed policy changes.
+- Run `redblue.challenge` to surface unintended consequences before implementation.
+
+## Quick checklist before finalising
+
+- [ ] Every loop is labelled `R` or `B` and the polarity of each edge is clear.
+- [ ] Assumptions list mentions missing data, external shocks, or boundary decisions.
+- [ ] Risks capture both short-term and long-term failure modes.
+- [ ] Mermaid diagram renders (copy/paste into [Mermaid Live Editor](https://mermaid.live/)).
+
+Document the context and version of the diagram so future updates can track how the system changed over time.

--- a/src/router/router.ts
+++ b/src/router/router.ts
@@ -1,68 +1,250 @@
-import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { McpServer, ToolCallback } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
+import type { ZodRawShape } from "zod";
+import { DEFAULT_RAZORS } from "../lib/razors.js";
+import { ReasoningMetadataSchema, sampleStructuredJson } from "../lib/structured.js";
+import type { RouterPlan, RouterStep } from "../lib/types.js";
+
+const ModeSchema = z.enum([
+    "socratic",
+    "abductive",
+    "razors.apply",
+    "systems",
+    "analogical",
+    "constraint",
+    "redblue",
+    "dialectic",
+    "scientific",
+    "self_explain",
+    "divergent",
+    "exec",
+]);
+
+const StepSchema = z.object({
+    mode: ModeSchema,
+    tool: z.string().optional(),
+    why: z.string(),
+    args: z.record(z.string(), z.unknown()).default({}),
+});
+
+const PlanSchema = z
+    .object({
+        steps: z.array(StepSchema).default([]),
+        notes: z.string().optional(),
+    })
+    .extend({ meta: ReasoningMetadataSchema.optional() });
+
+const InputSchema = z.object({
+    task: z.string().describe("User task or question"),
+    context: z.string().optional(),
+    maxSteps: z.number().int().positive().max(8).default(4),
+});
+
+const inputShape = InputSchema.shape as ZodRawShape;
+
+type InputArgs = z.output<typeof InputSchema>;
+type InputShape = typeof inputShape;
 
 export function registerRouter(server: McpServer): void {
+    const handler: ToolCallback<InputShape> = async ({ task, context, maxSteps }) => {
+        const prompt = `You are a planning assistant that selects reasoning tools for an autonomous analyst.
+Available modes and their corresponding tool IDs:
+- socratic -> socratic.inquire (scope + assumptions)
+- abductive -> abductive.hypothesize (generate hypotheses)
+- razors.apply -> razors.apply (Occam/Hitchens/Popper screening)
+- systems -> systems.map (causal loop diagram)
+- analogical -> analogical.map (transfer structure)
+- constraint -> constraint.solve (formulate/solve constraints)
+- redblue -> redblue.challenge (adversarial review)
+- dialectic -> dialectic.tas (thesis/antithesis/synthesis)
+- scientific -> reasoning.scientific (decompose + tests)
+- self_explain -> reasoning.self_explain (transparent rationale)
+- divergent -> reasoning.divergent_convergent (brainstorm then converge)
+- exec -> exec.run (sandboxed JS experiments)
+Task: ${task}
+Context: ${context ?? ""}
+
+Return strict JSON only:
+{
+  "steps": [
+    {"mode":"...","tool":"tool.id","why":"...","args":{}}
+  ],
+  "notes": "one-line on expected limitations"
+}
+Limit steps to ${maxSteps}. Always start by clarifying scope (socratic) unless the task is already extremely specific. Prefer constraint when explicit numeric/logical limits or optimisation keywords appear. Prefer systems when many interacting variables, feedback, or dynamics are mentioned. Prefer abductive for incomplete evidence or diagnosis tasks and schedule razors.apply immediately after any generative hypothesis/idea step. Use redblue for safety, risk, or deployment checks before final answers. Use analogical when a source domain is provided or comparative reasoning is requested. Invoke scientific when experiments/tests/data validation are required. Include tool IDs in the plan.`;
+
+        const { text } = await sampleStructuredJson({
+            server,
+            prompt,
+            maxTokens: 600,
+            schema: PlanSchema,
+            fallback: () => buildHeuristicPlan(task, context, maxSteps),
+        });
+
+        return { content: [{ type: "text", text }] };
+    };
+
     server.registerTool(
         "reasoning.router.plan",
         {
             title: "Plan reasoning approach",
             description:
-                "Given a task, propose an ordered plan of reasoning modes with brief rationale. Modes: dialectic, socratic, abductive, systems, redblue, analogical, constraint, razors.apply. Returns JSON.",
-            inputSchema: {
-                task: z.string().describe("User task or question"),
-                context: z.string().optional(),
-                maxSteps: z.number().int().positive().max(8).default(4),
-            },
+                "Given a task, propose an ordered plan of reasoning modes with brief rationale. Modes include dialectic, socratic, abductive, systems, redblue, analogical, constraint, razors.apply, scientific, self_explain, divergent, exec.",
+            inputSchema: inputShape,
         },
-        async ({ task, context, maxSteps }) => {
-            let planText: string | null = null;
-            try {
-                const resp = await server.server.createMessage({
-                    messages: [
-                        {
-                            role: "user",
-                            content: {
-                                type: "text",
-                                text: `You are a planner. Available modes: dialectic, socratic, abductive, systems, redblue, analogical, constraint, razors.apply.
-Task: ${task}
-Context: ${context ?? ""}
-
-Output as strict JSON only, no prose:
-{
-  "steps": [{"mode":"...", "why":"...", "args":{}}],
-  "notes": "one line on expected limitations"
-}
-Limit steps to ${maxSteps}. Prefer constraint when explicit numeric/logical constraints exist; prefer systems when many interacting variables; prefer abductive for incomplete data; use razors.apply after hypothesis lists; add redblue before finalization for safety; use analogical if helpful transfer exists; use dialectic when controversy/policy/value trade-offs; start with socratic for scoping.`,
-                            },
-                        },
-                    ],
-                    maxTokens: 500,
-                });
-                if (resp.content.type === "text") planText = resp.content.text.trim();
-            } catch { }
-
-            const fallback = {
-                steps: [
-                    { mode: "socratic", why: "Scope the task and unknowns", args: { depth: 2 } },
-                    { mode: "abductive", why: "Generate/test leading explanations or options", args: { k: 3 } },
-                    { mode: "razors.apply", why: "Prune via MDL/Occam and falsifiability", args: { razors: ["MDL", "Popper"] } },
-                ],
-                notes: "LLM sampling unavailable; rule-based fallback used.",
-            };
-
-            const json = safeParseJSON(planText) ?? fallback;
-            return { content: [{ type: "text", text: JSON.stringify(json, null, 2) }] };
-        }
+        handler
     );
 }
 
-function safeParseJSON(txt?: string | null) {
-    if (!txt) return null;
-    try {
-        return JSON.parse(txt);
-    } catch {
-        return null;
+function buildHeuristicPlan(task: string, context: string | undefined, maxSteps: number): RouterPlan {
+    const normalized = `${task} ${context ?? ""}`.toLowerCase();
+    const steps: RouterStep[] = [];
+
+    const push = (step: RouterStep) => {
+        if (steps.length >= maxSteps) return;
+        steps.push(step);
+    };
+
+    const contains = (pattern: RegExp) => pattern.test(normalized);
+
+    push({
+        mode: "socratic",
+        tool: "socratic.inquire",
+        why: "Clarify scope, success criteria, and hidden assumptions",
+        args: { depth: contains(/complex|strategy|roadmap/) ? 3 : 2 },
+    });
+
+    const needsHypotheses = contains(/diagnos|root cause|why|uncertain|hypothesis|investigat|anomal/);
+    const needsCreative = contains(/brainstorm|idea|innov|option|alternativ|explore/);
+    const needsSystems = contains(/system|feedback|loop|dynamics|ecosystem|supply|demand|stock|flow/);
+    const needsConstraint = contains(/constraint|optimi[sz]e|allocate|schedule|budget|limit|maximize|minimize|>=|<=|\b\d+/);
+    const needsRisk = contains(/risk|safety|security|privacy|abuse|attack|hazard|failure|compliance|bias/);
+    const contested = contains(/trade-?off|controvers|policy|ethic|disagree|stakeholder|debate/);
+    const wantsAnalogy = contains(/analogy|analog|similar to|compare|precedent|case study/);
+    const needsScientific = contains(/experiment|test|measurement|data|evidence|validate/);
+    const wantsSelfExplain = contains(/explain|rationale|justify|transparent|walkthrough/);
+    const codeOrCalc = contains(/code|script|function|regex|compute|calculate|algorithm|typescript|javascript|json/);
+
+    if (needsCreative) {
+        push({
+            mode: "divergent",
+            tool: "reasoning.divergent_convergent",
+            why: "Expand the option space before converging with explicit criteria",
+            args: { prompt: task, k: Math.min(5, Math.max(3, maxSteps)) },
+        });
     }
+
+    if (needsHypotheses) {
+        push({
+            mode: "abductive",
+            tool: "abductive.hypothesize",
+            why: "Generate and score candidate explanations",
+            args: { k: needsCreative ? 5 : 4, apply_razors: [...DEFAULT_RAZORS] },
+        });
+    }
+
+    if (needsSystems) {
+        push({
+            mode: "systems",
+            tool: "systems.map",
+            why: "Map feedback loops and leverage points",
+            args: { variables: [] },
+        });
+    }
+
+    if (wantsAnalogy) {
+        push({
+            mode: "analogical",
+            tool: "analogical.map",
+            why: "Transfer structure from analogous domains while flagging mismatches",
+            args: {},
+        });
+    }
+
+    if (needsConstraint) {
+        push({
+            mode: "constraint",
+            tool: "constraint.solve",
+            why: "Check feasibility against formal constraints or optimisation goals",
+            args: { model_json: "" },
+        });
+    }
+
+    if (needsScientific) {
+        push({
+            mode: "scientific",
+            tool: "reasoning.scientific",
+            why: "Design falsifiable tests and evidence checks",
+            args: { allow_tools: true },
+        });
+    }
+
+    if (codeOrCalc) {
+        push({
+            mode: "exec",
+            tool: "exec.run",
+            why: "Prototype or verify small computations in a sandbox",
+            args: { timeout_ms: 1500 },
+        });
+    }
+
+    if (wantsSelfExplain) {
+        push({
+            mode: "self_explain",
+            tool: "reasoning.self_explain",
+            why: "Produce transparent rationale, citations, and self-critique",
+            args: { allow_citations: true },
+        });
+    }
+
+    if (contested) {
+        push({
+            mode: "dialectic",
+            tool: "dialectic.tas",
+            why: "Surface thesis/antithesis and synthesize trade-offs",
+            args: { audience: "general" },
+        });
+    }
+
+    if (needsRisk) {
+        push({
+            mode: "redblue",
+            tool: "redblue.challenge",
+            why: "Stress-test for failure modes and mitigations before deployment",
+            args: { rounds: Math.min(3, Math.max(1, maxSteps - steps.length || 1)), focus: ["safety", "security", "bias"] },
+        });
+    }
+
+    const generatorUsed = steps.some((step) => step.mode === "abductive" || step.mode === "divergent");
+    if (generatorUsed) {
+        push({
+            mode: "razors.apply",
+            tool: "razors.apply",
+            why: "Prune or revise options using MDL, Bayesian Occam, Sagan, Hitchens, Hanlon, and Popper tests",
+            args: { razors: [...DEFAULT_RAZORS] },
+        });
+    }
+
+    if (!steps.some((step) => step.mode === "dialectic") && contested && steps.length < maxSteps) {
+        push({
+            mode: "dialectic",
+            tool: "dialectic.tas",
+            why: "Synthesize trade-offs before final decision",
+            args: { audience: "general" },
+        });
+    }
+
+    if (steps.length === 1 && steps[0].mode === "socratic") {
+        push({
+            mode: "scientific",
+            tool: "reasoning.scientific",
+            why: "Structure the next investigative steps when no other heuristic fired",
+            args: { allow_tools: true },
+        });
+    }
+
+    return {
+        steps,
+        notes: "Heuristic fallback generated from keyword analysis; rerun with sampling for nuanced sequencing.",
+    };
 }
-
-

--- a/src/tools/abductive.ts
+++ b/src/tools/abductive.ts
@@ -1,18 +1,45 @@
-import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { McpServer, ToolCallback } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
+import type { ZodRawShape } from "zod";
+import { DEFAULT_RAZORS, summarizeRazors } from "../lib/razors.js";
+import { ReasoningMetadataSchema, sampleStructuredJson } from "../lib/structured.js";
+
+const InputSchema = z.object({
+    observations: z.string(),
+    k: z.number().int().min(2).max(10).default(4),
+    apply_razors: z.array(z.string()).default([...DEFAULT_RAZORS]),
+});
+
+const inputShape = InputSchema.shape as ZodRawShape;
+
+type InputArgs = z.output<typeof InputSchema>;
+type InputShape = typeof inputShape;
+
+const OutputSchema = z
+    .object({
+        hypotheses: z
+            .array(
+                z.object({
+                    id: z.string(),
+                    statement: z.string(),
+                    rationale: z.string(),
+                    scores: z.object({
+                        prior_plausibility: z.number(),
+                        explanatory_power: z.number(),
+                        simplicity_penalty: z.number(),
+                        testability: z.number(),
+                        overall: z.number(),
+                    }),
+                })
+            )
+            .default([]),
+        experiments_or_evidence: z.array(z.string()).default([]),
+        notes: z.string().optional(),
+    })
+    .extend({ meta: ReasoningMetadataSchema.optional() });
 
 export function registerAbductive(server: McpServer): void {
-    const config = {
-        title: "Abductive hypotheses",
-        description:
-            "Generate k candidate hypotheses and rank by plausibility, explanatory power, simplicity (MDL proxy), and testability.",
-        inputSchema: {
-            observations: z.string(),
-            k: z.number().int().min(2).max(10).default(4),
-            apply_razors: z.array(z.string()).default(["MDL", "Hitchens", "Sagan", "Popper"]),
-        },
-    };
-    const handler = async ({ observations, k, apply_razors }: { observations: string; k: number; apply_razors: string[] }) => {
+    const handler: ToolCallback<InputShape> = async ({ observations, k, apply_razors }) => {
         const prompt = `Observations:\n${observations}
 
 Generate ${k} abductive hypotheses. Score each on:
@@ -22,7 +49,9 @@ Generate ${k} abductive hypotheses. Score each on:
 - testability (0-1)
 - overall_score = prior_plausibility + explanatory_power + testability - simplicity_penalty
 
-Apply razors: ${apply_razors.join(", ")}.
+Apply the following razors and reference them explicitly where relevant:
+${summarizeRazors(apply_razors)}
+
 Return strict JSON only:
 {
  "hypotheses": [
@@ -31,14 +60,38 @@ Return strict JSON only:
  "experiments_or_evidence": ["test1"],
  "notes": "..."
 }`;
-        const resp = await server.server.createMessage({
-            messages: [{ role: "user", content: { type: "text", text: prompt } }],
+        const { text } = await sampleStructuredJson({
+            server,
+            prompt,
             maxTokens: 900,
+            schema: OutputSchema,
+            fallback: () => ({
+                hypotheses: Array.from({ length: Math.min(k, 3) }, (_, idx) => ({
+                    id: `H${idx + 1}`,
+                    statement: `Coherent explanation candidate ${idx + 1}`,
+                    rationale: "Sketch causal story consistent with observations.",
+                    scores: {
+                        prior_plausibility: 0.5 - idx * 0.05,
+                        explanatory_power: 0.6 - idx * 0.05,
+                        simplicity_penalty: 0.2 + idx * 0.1,
+                        testability: 0.6 - idx * 0.05,
+                        overall: 1.5 - idx * 0.1,
+                    },
+                })),
+                experiments_or_evidence: ["Design discriminating test or gather missing data."],
+                notes: "Deterministic fallback applied; rerun with sampling for richer detail.",
+            }),
         });
-        return { content: [{ type: "text", text: resp.content.type === "text" ? resp.content.text : "{}" }] };
+        return { content: [{ type: "text", text }] };
     };
-    server.registerTool("abductive.hypothesize", config as any, handler as any);
-    server.registerTool("abductive_hypothesize", config as any, handler as any);
+
+    const config = {
+        title: "Abductive hypotheses",
+        description:
+            "Generate k candidate hypotheses and rank by plausibility, explanatory power, simplicity (MDL proxy), and testability.",
+        inputSchema: inputShape,
+    };
+
+    server.registerTool("abductive.hypothesize", config, handler);
+    server.registerTool("abductive_hypothesize", config, handler);
 }
-
-

--- a/src/tools/constraint.ts
+++ b/src/tools/constraint.ts
@@ -1,10 +1,24 @@
-import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { McpServer, ToolCallback } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
+import type { ZodRawShape } from "zod";
 import { parseModel } from "../lib/dsl.js";
 import { init } from "z3-solver";
 
-function serializeModel(entries: [string, any][]) {
-    const model: Record<string, string> = {};
+type SerializedModel = Record<string, string>;
+
+type SolverEntry = [string, any];
+
+const InputSchema = z.object({
+    model_json: z.string().describe("JSON with {variables, constraints, optimize?}"),
+});
+
+const inputShape = InputSchema.shape as ZodRawShape;
+
+type InputArgs = z.output<typeof InputSchema>;
+type InputShape = typeof inputShape;
+
+function serializeModel(entries: SolverEntry[]): SerializedModel {
+    const model: SerializedModel = {};
     for (const [name, value] of entries) {
         if (value !== undefined && value !== null) {
             model[name] = value.toString();
@@ -14,91 +28,61 @@ function serializeModel(entries: [string, any][]) {
 }
 
 export function registerConstraint(server: McpServer): void {
-    server.registerTool(
-        "constraint.solve",
-        {
-            title: "Constraint solver (Z3)",
-            description:
-                "Solve constraints using Z3. Input mini-DSL as JSON (variables, constraints, optional optimize).",
-            inputSchema: { model_json: z.string().describe("JSON with {variables, constraints, optimize?}") },
-        },
-        async ({ model_json }) => {
-            let req;
-            try {
-                req = parseModel(model_json);
-            } catch (e: any) {
-                return {
-                    content: [
-                        {
-                            type: "text",
-                            text: JSON.stringify({ error: e?.message || "Invalid model_json" }, null, 2),
-                        },
-                    ],
-                };
+    const handler: ToolCallback<InputShape> = async ({ model_json }) => {
+        let req;
+        try {
+            req = parseModel(model_json);
+        } catch (e: unknown) {
+            return {
+                content: [
+                    {
+                        type: "text",
+                        text: JSON.stringify({ error: (e as Error)?.message ?? "Invalid model_json" }, null, 2),
+                    },
+                ],
+            };
+        }
+
+        try {
+            const { Context } = await init();
+            const ctx = Context("reason-suite-constraint");
+            const { Solver, Optimize, Int, Real, Bool } = ctx;
+
+            const declarations: string[] = [];
+            const variableSymbols: Record<string, any> = {};
+
+            for (const variable of req.variables) {
+                declarations.push(`(declare-const ${variable.name} ${variable.type})`);
+                if (variable.type === "Int") {
+                    variableSymbols[variable.name] = Int.const(variable.name);
+                } else if (variable.type === "Real") {
+                    variableSymbols[variable.name] = Real.const(variable.name);
+                } else {
+                    variableSymbols[variable.name] = Bool.const(variable.name);
+                }
             }
 
-            try {
-                const { Context } = await init();
-                const ctx = Context("reason-suite-constraint");
-                const { Solver, Optimize, Int, Real, Bool } = ctx;
+            const assertions = req.constraints.map((c) => `(assert ${c})`);
+            const baseScript = [...declarations, ...assertions].join("\n");
 
-                const declarations: string[] = [];
-                const variableSymbols: Record<string, any> = {};
+            if (req.optimize && req.optimize.objective) {
+                const opt = new Optimize();
+                const sense = req.optimize.sense === "min" ? "minimize" : "maximize";
+                const script = [baseScript, `(${sense} ${req.optimize.objective})`]
+                    .filter((section) => section.length > 0)
+                    .join("\n");
 
-                for (const variable of req.variables) {
-                    declarations.push(`(declare-const ${variable.name} ${variable.type})`);
-                    if (variable.type === "Int") {
-                        variableSymbols[variable.name] = Int.const(variable.name);
-                    } else if (variable.type === "Real") {
-                        variableSymbols[variable.name] = Real.const(variable.name);
-                    } else {
-                        variableSymbols[variable.name] = Bool.const(variable.name);
-                    }
+                if (script.length > 0) {
+                    opt.fromString(script);
                 }
 
-                const assertions = req.constraints.map((c) => `(assert ${c})`);
-                const baseScript = [...declarations, ...assertions].join("\n");
-
-                if (req.optimize && req.optimize.objective) {
-                    const opt = new Optimize();
-                    const sense = req.optimize.sense === "min" ? "minimize" : "maximize";
-                    const script = [baseScript, `(${sense} ${req.optimize.objective})`]
-                        .filter((section) => section.length > 0)
-                        .join("\n");
-
-                    if (script.length > 0) {
-                        opt.fromString(script);
-                    }
-
-                    const status = await opt.check();
-                    if (status !== "sat") {
-                        return { content: [{ type: "text", text: JSON.stringify({ status }, null, 2) }] };
-                    }
-
-                    const model = opt.model();
-                    const entries = Object.entries(variableSymbols).map(([name, sym]) => [name, model.get(sym)] as [string, any]);
-                    return {
-                        content: [
-                            {
-                                type: "text",
-                                text: JSON.stringify({ status, model: serializeModel(entries) }, null, 2),
-                            },
-                        ],
-                    };
-                }
-
-                const solver = new Solver();
-                if (baseScript.length > 0) {
-                    solver.fromString(baseScript);
-                }
-
-                const status = await solver.check();
+                const status = await opt.check();
                 if (status !== "sat") {
                     return { content: [{ type: "text", text: JSON.stringify({ status }, null, 2) }] };
                 }
 
-                const model = solver.model();
-                const entries = Object.entries(variableSymbols).map(([name, sym]) => [name, model.get(sym)] as [string, any]);
+                const model = opt.model();
+                const entries = Object.entries(variableSymbols).map(([name, sym]) => [name, model.get(sym)] as SolverEntry);
                 return {
                     content: [
                         {
@@ -107,10 +91,41 @@ export function registerConstraint(server: McpServer): void {
                         },
                     ],
                 };
-            } catch (err: any) {
-                const message = err?.message ?? "Solver error";
-                return { content: [{ type: "text", text: JSON.stringify({ error: message }, null, 2) }] };
             }
+
+            const solver = new Solver();
+            if (baseScript.length > 0) {
+                solver.fromString(baseScript);
+            }
+
+            const status = await solver.check();
+            if (status !== "sat") {
+                return { content: [{ type: "text", text: JSON.stringify({ status }, null, 2) }] };
+            }
+
+            const model = solver.model();
+            const entries = Object.entries(variableSymbols).map(([name, sym]) => [name, model.get(sym)] as SolverEntry);
+            return {
+                content: [
+                    {
+                        type: "text",
+                        text: JSON.stringify({ status, model: serializeModel(entries) }, null, 2),
+                    },
+                ],
+            };
+        } catch (err: unknown) {
+            const message = (err as Error)?.message ?? "Solver error";
+            return { content: [{ type: "text", text: JSON.stringify({ error: message }, null, 2) }] };
         }
+    };
+
+    server.registerTool(
+        "constraint.solve",
+        {
+            title: "Constraint solver (Z3)",
+            description: "Solve constraints using Z3. Input mini-DSL as JSON (variables, constraints, optional optimize).",
+            inputSchema: inputShape,
+        },
+        handler
     );
 }

--- a/src/tools/razors.ts
+++ b/src/tools/razors.ts
@@ -1,36 +1,76 @@
-import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { McpServer, ToolCallback } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
+import type { ZodRawShape } from "zod";
+import { DEFAULT_RAZORS, summarizeRazors } from "../lib/razors.js";
+import { ReasoningMetadataSchema, sampleStructuredJson } from "../lib/structured.js";
+
+const InputSchema = z.object({
+    candidates_json: z.string().describe("JSON array or object of candidates"),
+    razors: z.array(z.string()).default([...DEFAULT_RAZORS]),
+});
+
+const inputShape = InputSchema.shape as ZodRawShape;
+
+type InputArgs = z.output<typeof InputSchema>;
+type InputShape = typeof inputShape;
+
+const OutputSchema = z
+    .object({
+        results: z
+            .array(
+                z.object({
+                    id: z.string(),
+                    keep_or_drop: z.enum(["keep", "drop", "revise"]),
+                    reasons: z.array(z.string()).default([]),
+                    risk_notes: z.string().optional(),
+                })
+            )
+            .default([]),
+        shortlist: z.array(z.string()).default([]),
+        notes: z.string().optional(),
+    })
+    .extend({ meta: ReasoningMetadataSchema.optional() });
 
 export function registerRazors(server: McpServer): void {
-    server.registerTool(
-        "razors.apply",
-        {
-            title: "Apply reasoning razors",
-            description:
-                "Given candidate explanations, apply Occam/MDL, Bayesian Occam, Sagan, Hitchens, Hanlon, Popper falsifiability to produce keep/drop recommendations.",
-            inputSchema: {
-                candidates_json: z.string().describe("JSON array or object of candidates"),
-                razors: z
-                    .array(z.string())
-                    .default(["MDL", "BayesianOccam", "Sagan", "Hitchens", "Hanlon", "Popper"]),
-            },
-        },
-        async ({ candidates_json, razors }) => {
-            const prompt = `Candidates JSON:\n${candidates_json}
-Razors: ${razors.join(", ")}
+    const handler: ToolCallback<InputShape> = async ({ candidates_json, razors }) => {
+        const prompt = `Candidates JSON:\n${candidates_json}
+Razors to apply (explain how each affects the verdict):
+${summarizeRazors(razors)}
 
 For each candidate produce JSON objects:
 {"id":"...","keep_or_drop":"keep|drop|revise","reasons":["..."],"risk_notes":"..."}
 
 Return strict JSON only:
 { "results": [...], "shortlist": ["ids..."], "notes": "..." }`;
-            const resp = await server.server.createMessage({
-                messages: [{ role: "user", content: { type: "text", text: prompt } }],
-                maxTokens: 700,
-            });
-            return { content: [{ type: "text", text: resp.content.type === "text" ? resp.content.text : "{}" }] };
-        }
+        const { text } = await sampleStructuredJson({
+            server,
+            prompt,
+            maxTokens: 700,
+            schema: OutputSchema,
+            fallback: () => ({
+                results: [
+                    {
+                        id: "candidate-1",
+                        keep_or_drop: "keep" as const,
+                        reasons: ["Simplest explanation consistent with MDL", "Survives Popper falsifiability"],
+                        risk_notes: "Monitor for new contradictory evidence",
+                    },
+                ],
+                shortlist: ["candidate-1"],
+                notes: "Deterministic fallback applied; validate candidates_json structure.",
+            }),
+        });
+        return { content: [{ type: "text", text }] };
+    };
+
+    server.registerTool(
+        "razors.apply",
+        {
+            title: "Apply reasoning razors",
+            description:
+                "Given candidate explanations, apply Occam/MDL, Bayesian Occam, Sagan, Hitchens, Hanlon, Popper falsifiability to produce keep/drop recommendations.",
+            inputSchema: inputShape,
+        },
+        handler
     );
 }
-
-

--- a/src/tools/redblue.ts
+++ b/src/tools/redblue.ts
@@ -1,18 +1,53 @@
-import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { McpServer, ToolCallback } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
+import type { ZodRawShape } from "zod";
+import { ReasoningMetadataSchema, sampleStructuredJson } from "../lib/structured.js";
+
+const InputSchema = z.object({
+    proposal: z.string(),
+    rounds: z.number().int().min(1).max(5).default(2),
+    focus: z.array(z.string()).default(["safety", "bias", "hallucination", "security", "privacy"]),
+});
+
+const inputShape = InputSchema.shape as ZodRawShape;
+
+type InputArgs = z.output<typeof InputSchema>;
+type InputShape = typeof inputShape;
+
+const OutputSchema = z
+    .object({
+        rounds: z
+            .array(
+                z.object({
+                    n: z.number().int(),
+                    red: z.object({ attack: z.string() }),
+                    blue: z.object({
+                        defense: z.string(),
+                        mitigations: z.array(z.string()).default([]),
+                    }),
+                })
+            )
+            .default([]),
+        defects: z
+            .array(
+                z.object({
+                    type: z.string(),
+                    severity: z.enum(["low", "med", "high"]),
+                    evidence: z.string(),
+                })
+            )
+            .default([]),
+        risk_matrix: z.object({
+            low: z.array(z.string()).default([]),
+            medium: z.array(z.string()).default([]),
+            high: z.array(z.string()).default([]),
+        }),
+        final_guidance: z.array(z.string()).default([]),
+    })
+    .extend({ meta: ReasoningMetadataSchema.optional() });
 
 export function registerRedBlue(server: McpServer): void {
-    const config = {
-        title: "Red vs Blue critique",
-        description:
-            "Run N rounds of adversarial challenge/defense on a proposal or answer. Returns a transcript + defects + risk matrix.",
-        inputSchema: {
-            proposal: z.string(),
-            rounds: z.number().int().min(1).max(5).default(2),
-            focus: z.array(z.string()).default(["safety", "bias", "hallucination", "security", "privacy"]),
-        },
-    };
-    const handler = async ({ proposal, rounds, focus }: { proposal: string; rounds: number; focus: string[] }) => {
+    const handler: ToolCallback<InputShape> = async ({ proposal, rounds, focus }) => {
         const prompt = `Conduct ${rounds} rounds of Red (attack) vs Blue (defense) on:
 ${proposal}
 
@@ -26,14 +61,37 @@ Return strict JSON only:
  "risk_matrix":{"low":[],"medium":[],"high":[]},
  "final_guidance":["..."]
 }`;
-        const resp = await server.server.createMessage({
-            messages: [{ role: "user", content: { type: "text", text: prompt } }],
+        const { text } = await sampleStructuredJson({
+            server,
+            prompt,
             maxTokens: 900,
+            schema: OutputSchema,
+            fallback: () => ({
+                rounds: Array.from({ length: rounds }, (_, idx) => ({
+                    n: idx + 1,
+                    red: { attack: `Stress scenario ${idx + 1}: probe ${focus[idx % focus.length] ?? "failure"}` },
+                    blue: {
+                        defense: "Document mitigations and residual risks.",
+                        mitigations: ["Add guardrails", "Strengthen monitoring"],
+                    },
+                })),
+                defects: [
+                    { type: "coverage_gap", severity: "med" as const, evidence: "Fallback analysis" },
+                ],
+                risk_matrix: { low: ["low impact issues"], medium: ["monitor residual risk"], high: [] },
+                final_guidance: ["Close medium risks", "Schedule re-test after mitigations"],
+            }),
         });
-        return { content: [{ type: "text", text: resp.content.type === "text" ? resp.content.text : "{}" }] };
+        return { content: [{ type: "text", text }] };
     };
-    server.registerTool("redblue.challenge", config as any, handler as any);
-    server.registerTool("redblue_challenge", config as any, handler as any);
+
+    const config = {
+        title: "Red vs Blue critique",
+        description:
+            "Run N rounds of adversarial challenge/defense on a proposal or answer. Returns a transcript + defects + risk matrix.",
+        inputSchema: inputShape,
+    };
+
+    server.registerTool("redblue.challenge", config, handler);
+    server.registerTool("redblue_challenge", config, handler);
 }
-
-

--- a/src/tools/selector.ts
+++ b/src/tools/selector.ts
@@ -1,0 +1,562 @@
+import type { McpServer, ToolCallback } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import type { ZodRawShape } from "zod";
+import { DEFAULT_RAZORS, RAZOR_DESCRIPTIONS } from "../lib/razors.js";
+import { ReasoningMetadataSchema, sampleStructuredJson } from "../lib/structured.js";
+import type { ReasoningMode } from "../lib/types.js";
+
+const MODE_IDS = [
+    "socratic",
+    "abductive",
+    "razors.apply",
+    "systems",
+    "analogical",
+    "constraint",
+    "redblue",
+    "dialectic",
+    "scientific",
+    "self_explain",
+    "divergent",
+    "exec",
+] as const satisfies readonly ReasoningMode[];
+
+type ModeId = (typeof MODE_IDS)[number];
+
+type ModeProfile = {
+    label: string;
+    summary: string;
+    cues: string[];
+    signals: RegExp[];
+    base: number;
+};
+
+const MODE_CATALOG: Record<ModeId, ModeProfile> = {
+    socratic: {
+        label: "Socratic Inquiry",
+        summary: "Clarify scope, surface assumptions, and define success criteria before committing to a path.",
+        cues: ["Ambiguous scope", "Multiple stakeholders", "Missing success definition"],
+        signals: [/clarif/i, /scope/i, /assumption/i, /unknown/i],
+        base: 0.45,
+    },
+    abductive: {
+        label: "Abductive Hypothesis Ranking",
+        summary: "Generate and score competing explanations when evidence is incomplete or ambiguous.",
+        cues: ["Diagnosis", "Root cause", "Why did this happen"],
+        signals: [/diagnos/i, /root cause/i, /why/i, /hypoth/i, /anomal/i, /myster/i],
+        base: 0.25,
+    },
+    "razors.apply": {
+        label: "Razor Screening",
+        summary: "Apply Occam/MDL, Bayesian Occam, Sagan, Hitchens, Hanlon, and Popper tests to prune weak options.",
+        cues: ["Need to prune options", "Screen speculative claims", "Check plausibility"],
+        signals: [/razor/i, /occam/i, /plausib/i, /speculat/i, /option/i, /hypoth/i, /choose/i],
+        base: 0.2,
+    },
+    systems: {
+        label: "Systems Mapping",
+        summary: "Map feedback loops, stocks/flows, and leverage points across interacting factors.",
+        cues: ["Ecosystems", "Dynamics", "Feedback loops"],
+        signals: [/system/i, /feedback/i, /loop/i, /dynamic/i, /ecosystem/i, /interdepend/i, /supply/i, /demand/i],
+        base: 0.2,
+    },
+    analogical: {
+        label: "Analogical Mapping",
+        summary: "Transfer structure from an analogous case while flagging mismatches and limits.",
+        cues: ["Compare domains", "Look for precedent", "Use analogy"],
+        signals: [/analog/i, /similar/i, /compare/i, /precedent/i, /case study/i, /metaphor/i],
+        base: 0.15,
+    },
+    constraint: {
+        label: "Constraint Solver",
+        summary: "Encode limits/optimization goals as constraints, test feasibility, or optimize outcomes.",
+        cues: ["Optimization", "Scheduling", "Budget/limits"],
+        signals: [/constraint/i, /optimi[sz]/i, /schedule/i, /budget/i, /allocat/i, /limit/i, />=/, /<=/, /maximize/i, /minimi/i, /\b\d+\b/],
+        base: 0.18,
+    },
+    redblue: {
+        label: "Red/Blue Challenge",
+        summary: "Stress-test for failure modes, attacks, safety hazards, and mitigations.",
+        cues: ["Safety review", "Risk assessment", "Adversarial thinking"],
+        signals: [/risk/i, /safety/i, /attack/i, /threat/i, /abuse/i, /hazard/i, /failure/i, /compliance/i, /bias/i, /security/i],
+        base: 0.22,
+    },
+    dialectic: {
+        label: "Dialectic TAS",
+        summary: "Lay out thesis, antithesis, and synthesis for contested, multi-perspective issues.",
+        cues: ["Debates", "Trade-offs", "Policy tension"],
+        signals: [/debate/i, /controvers/i, /trade-?off/i, /stakeholder/i, /disagree/i, /policy/i, /ethic/i],
+        base: 0.18,
+    },
+    scientific: {
+        label: "Scientific Method",
+        summary: "Design falsifiable experiments, define evidence needs, and plan validation steps.",
+        cues: ["Experiments", "Data validation", "Measurement"],
+        signals: [/experiment/i, /test/i, /measurement/i, /data/i, /evidence/i, /validate/i, /metric/i],
+        base: 0.2,
+    },
+    self_explain: {
+        label: "Self-Explanation",
+        summary: "Produce transparent rationales, intermediate steps, and self-critique.",
+        cues: ["Explain reasoning", "Trace logic", "Audit trail"],
+        signals: [/explain/i, /rationale/i, /justify/i, /walkthrough/i, /transparent/i, /trace/i],
+        base: 0.16,
+    },
+    divergent: {
+        label: "Divergent → Convergent",
+        summary: "Expand the option space then evaluate with explicit criteria before choosing a winner.",
+        cues: ["Brainstorm", "Generate options", "Ideation"],
+        signals: [/brainstorm/i, /idea/i, /innov/i, /option/i, /alternativ/i, /explore/i, /creative/i],
+        base: 0.2,
+    },
+    exec: {
+        label: "Execution Sandbox",
+        summary: "Run quick code or calculations in a sandbox to prototype or verify results.",
+        cues: ["Code", "Scripts", "Computation"],
+        signals: [/code/i, /script/i, /function/i, /regex/i, /compute/i, /calculate/i, /algorithm/i, /typescript/i, /javascript/i, /json/i],
+        base: 0.1,
+    },
+};
+
+const MODE_SET = new Set<ModeId>(MODE_IDS);
+
+const RAZOR_HINTS: Record<
+    string,
+    {
+        label: string;
+        cues: string;
+        signals: RegExp[];
+    }
+> = {
+    MDL: {
+        label: "Minimum Description Length",
+        cues: "Complex explanations, many moving parts, overfit stories",
+        signals: [/complex/i, /overly/i, /complicated/i, /many assumptions/i, /sprawl/i],
+    },
+    BayesianOccam: {
+        label: "Bayesian Occam",
+        cues: "Scarce evidence, need to balance priors vs likelihood",
+        signals: [/probab/i, /likelihood/i, /bayes/i, /prior/i, /belief/i, /uncertain/i],
+    },
+    Sagan: {
+        label: "Sagan Standard",
+        cues: "Extraordinary or dramatic claims lacking proportionate proof",
+        signals: [/extraordinary/i, /incredible/i, /unprecedented/i, /miracle/i, /massive/i, /sweeping/i],
+    },
+    Hitchens: {
+        label: "Hitchens' Razor",
+        cues: "Assertions without evidence or cited support",
+        signals: [/claim/i, /assert/i, /rumor/i, /unsubstanti/i, /without evidence/i, /no proof/i],
+    },
+    Hanlon: {
+        label: "Hanlon's Razor",
+        cues: "Attributing harm to malice when incompetence or noise suffice",
+        signals: [/malice/i, /evil/i, /malicious/i, /nefarious/i, /intentional harm/i, /sabotage/i],
+    },
+    Popper: {
+        label: "Popper Falsifiability",
+        cues: "Hypotheses, theories, or policies needing falsification tests",
+        signals: [/falsif/i, /test/i, /experiment/i, /hypoth/i, /theory/i, /predict/i, /refut/i],
+    },
+};
+
+const InputSchema = z.object({
+    request: z.string().describe("Original user prompt or task"),
+    context: z.string().optional(),
+    candidate_modes: z.array(z.string()).default([...MODE_IDS]),
+    candidate_razors: z.array(z.string()).default([...DEFAULT_RAZORS]),
+});
+
+const inputShape = InputSchema.shape as ZodRawShape;
+
+type InputArgs = z.output<typeof InputSchema>;
+type InputShape = typeof inputShape;
+
+type ModeScore = {
+    id: ModeId;
+    label: string;
+    score: number;
+    reason: string;
+};
+
+type RazorScore = {
+    id: string;
+    label: string;
+    score: number;
+    reason: string;
+};
+
+const OutputSchema = z
+    .object({
+        primary_mode: z.object({
+            id: z.string(),
+            label: z.string(),
+            confidence: z.number().min(0).max(1),
+            reason: z.string(),
+        }),
+        supporting_modes: z
+            .array(
+                z.object({
+                    id: z.string(),
+                    label: z.string(),
+                    score: z.number().min(0).max(1),
+                    reason: z.string(),
+                })
+            )
+            .default([]),
+        razor_stack: z
+            .array(
+                z.object({
+                    id: z.string(),
+                    label: z.string(),
+                    score: z.number().min(0).max(1),
+                    reason: z.string(),
+                })
+            )
+            .default([]),
+        decision_path: z
+            .array(
+                z.object({
+                    observation: z.string(),
+                    implication: z.string(),
+                })
+            )
+            .default([]),
+        next_action: z.string().optional(),
+        notes: z.string().optional(),
+    })
+    .extend({ meta: ReasoningMetadataSchema.optional() });
+
+function isModeId(value: string): value is ModeId {
+    return MODE_SET.has(value as ModeId);
+}
+
+function renderModeCatalog(modeIds: ModeId[]): string {
+    return modeIds
+        .map((id) => {
+            const info = MODE_CATALOG[id];
+            if (!info) {
+                return `- ${id}: General reasoning mode.`;
+            }
+            return `- ${id} (${info.label}): ${info.summary} Signals: ${info.cues.join(", ")}`;
+        })
+        .join("\n");
+}
+
+function renderRazorCatalog(razorIds: string[]): string {
+    return razorIds
+        .map((id) => {
+            const description = RAZOR_DESCRIPTIONS[id] ?? "No stored description.";
+            const hint = RAZOR_HINTS[id];
+            if (!hint) {
+                return `- ${id}: ${description}`;
+            }
+            return `- ${id}: ${description} Signals: ${hint.cues}`;
+        })
+        .join("\n");
+}
+
+function clampScore(value: number): number {
+    return Math.max(0, Math.min(1, Number(value.toFixed(2))));
+}
+
+function buildFallback(
+    request: string,
+    context: string | undefined,
+    modes: ModeId[],
+    razors: string[]
+) {
+    const text = `${request} ${context ?? ""}`.toLowerCase();
+    const available = new Set<ModeId>(modes);
+    const scores = new Map<ModeId, number>();
+    const reasons = new Map<ModeId, Set<string>>();
+    const decisionPath: { observation: string; implication: string }[] = [];
+
+    const addReason = (id: ModeId, reason: string, delta: number) => {
+        if (!available.has(id)) return;
+        scores.set(id, (scores.get(id) ?? MODE_CATALOG[id]?.base ?? 0.1) + delta);
+        const store = reasons.get(id) ?? new Set<string>();
+        store.add(reason);
+        reasons.set(id, store);
+    };
+
+    const note = (observation: string, implication: string) => {
+        decisionPath.push({ observation, implication });
+    };
+
+    // Baseline for Socratic if available
+    if (available.has("socratic")) {
+        scores.set("socratic", MODE_CATALOG.socratic.base);
+        reasons.set("socratic", new Set(["Default clarifying step for ambiguous prompts."]));
+    }
+
+    const detect = (pattern: RegExp, onHit: () => void, observation: string, implication: string) => {
+        if (pattern.test(text)) {
+            note(observation, implication);
+            onHit();
+            return true;
+        }
+        return false;
+    };
+
+    const creative = detect(
+        /brainstorm|idea|innov|option|alternativ|explore|creative|greenfield/,
+        () => {
+            addReason("divergent", "Creative/ideation language detected", 0.45);
+            addReason("razors.apply", "Need to prune after ideation", 0.25);
+        },
+        "Detected creative ideation cues (brainstorm/idea/etc.)",
+        "Favors divergent exploration followed by razor pruning"
+    );
+
+    const hypotheses = detect(
+        /diagnos|root cause|why|hypothes|investigat|anomal|myster|interpret/,
+        () => {
+            addReason("abductive", "Diagnosis/root-cause language", 0.4);
+            addReason("razors.apply", "Hypotheses benefit from razor screening", 0.22);
+        },
+        "Found diagnosis/root-cause cues",
+        "Points to abductive hypothesis ranking and razor screening"
+    );
+
+    detect(
+        /system|feedback|loop|dynamic|ecosystem|interdepend|supply|demand|network|ripple/,
+        () => addReason("systems", "Systems/dynamics vocabulary", 0.42),
+        "Systems or dynamics terminology present",
+        "Map causal loops and leverage points"
+    );
+
+    const constraint = detect(
+        /constraint|optimi[sz]|schedule|budget|allocat|limit|maximi|minimi|>=|<=|\b\d+\b|tradeoff curve|capacity/,
+        () => addReason("constraint", "Optimization/constraint cues", 0.48),
+        "Optimization or numeric constraints noted",
+        "Prefer constraint solving to test feasibility"
+    );
+
+    const risk = detect(
+        /risk|safety|attack|threat|abuse|hazard|failure|compliance|bias|exploit|breach/,
+        () => addReason("redblue", "Risk/threat keywords", 0.46),
+        "Risk or adversarial words detected",
+        "Red/blue challenge to stress-test mitigations"
+    );
+
+    detect(
+        /debate|controvers|trade-?off|stakeholder|disagree|policy|ethic|tension/,
+        () => addReason("dialectic", "Contested/dual-view framing", 0.38),
+        "Contested or policy language present",
+        "Dialectic TAS to surface trade-offs"
+    );
+
+    detect(
+        /analog|similar|compare|precedent|case study|metaphor|analogy/,
+        () => addReason("analogical", "Analogy/comparison keywords", 0.4),
+        "Analogy or comparison cues",
+        "Analogical mapping to transfer structure and flag mismatches"
+    );
+
+    detect(
+        /experiment|test|measurement|metric|data|evidence|validate|trial|prototype/,
+        () => addReason("scientific", "Experiment/test language", 0.42),
+        "Experimentation or evidence gathering requested",
+        "Scientific decomposition to plan falsifiable tests"
+    );
+
+    const explain = detect(
+        /explain|justify|rationale|walkthrough|transparent|audit|trace/,
+        () => addReason("self_explain", "Transparency/explanation cues", 0.38),
+        "Transparency or explanation requested",
+        "Self-explanation to make reasoning explicit"
+    );
+
+    const code = detect(
+        /code|script|function|regex|compute|calculate|algorithm|typescript|javascript|python|json|simulate|prototype/,
+        () => addReason("exec", "Coding/calculation keywords", 0.5),
+        "Code or computation keywords present",
+        "Execution sandbox to quickly verify computations"
+    );
+
+    const razorExplicit = detect(
+        /razor|occam|popper|hanlon|hitchens|sagan|bayesian occam/,
+        () => addReason("razors.apply", "Explicit razor reference", 0.55),
+        "Explicit request for razors",
+        "Use razor screening as the primary move"
+    );
+
+    if (!razorExplicit && !creative && !hypotheses) {
+        // Keep razor as supporting option if available
+        addReason("razors.apply", "General plausibility pruning", 0.1);
+    }
+
+    // If no signals besides baseline, ensure Socratic remains viable
+    if (decisionPath.length === 0 && available.has("socratic")) {
+        note("No strong heuristic signals detected", "Default to Socratic questioning to clarify scope");
+    }
+
+    const modeScores: ModeScore[] = modes.map((mode) => {
+        const profile = MODE_CATALOG[mode];
+        const score = clampScore(scores.get(mode) ?? profile?.base ?? 0.1);
+        const reasonSet = reasons.get(mode);
+        const reason = reasonSet && reasonSet.size > 0 ? Array.from(reasonSet).join("; ") : profile?.summary ?? "General utility.";
+        return {
+            id: mode,
+            label: profile?.label ?? mode,
+            score,
+            reason,
+        };
+    });
+
+    modeScores.sort((a, b) => b.score - a.score);
+    const primary = modeScores[0] ?? {
+        id: modes[0]!,
+        label: MODE_CATALOG[modes[0] as ModeId]?.label ?? modes[0]!,
+        score: clampScore(MODE_CATALOG[modes[0] as ModeId]?.base ?? 0.4),
+        reason: MODE_CATALOG[modes[0] as ModeId]?.summary ?? "Default primary mode.",
+    };
+
+    const supporting = modeScores.slice(1, 4).filter((entry) => entry.score >= 0.15);
+
+    const razorScores = rankRazorsFallback({
+        request,
+        context,
+        razors,
+        creative,
+        hypotheses,
+        risk,
+        explain,
+        code,
+        constraint,
+    });
+
+    const nextAction = supporting.length
+        ? `Lead with ${primary.label} then consider ${supporting[0]!.label}${razorScores.length ? ` and apply ${razorScores
+              .map((r) => r.label)
+              .slice(0, 2)
+              .join("/")} razors` : ""}.`
+        : razorScores.length
+          ? `Lead with ${primary.label} and stack ${razorScores.map((r) => r.label).slice(0, 2).join("/")} razors.`
+          : `Lead with ${primary.label}.`;
+
+    return {
+        primary_mode: {
+            id: primary.id,
+            label: primary.label,
+            confidence: clampScore(primary.score),
+            reason: primary.reason,
+        },
+        supporting_modes: supporting.map((entry) => ({
+            id: entry.id,
+            label: entry.label,
+            score: clampScore(entry.score),
+            reason: entry.reason,
+        })),
+        razor_stack: razorScores,
+        decision_path: decisionPath.slice(0, 4),
+        next_action: nextAction,
+        notes: "Deterministic heuristic fallback. Re-run with model sampling for richer rationale.",
+    };
+}
+
+function rankRazorsFallback(opts: {
+    request: string;
+    context: string | undefined;
+    razors: string[];
+    creative: boolean;
+    hypotheses: boolean;
+    risk: boolean;
+    explain: boolean;
+    code: boolean;
+    constraint: boolean;
+}): RazorScore[] {
+    const { request, context, razors, creative, hypotheses, risk, explain, code, constraint } = opts;
+    const text = `${request} ${context ?? ""}`.toLowerCase();
+    const results: RazorScore[] = [];
+
+    for (const id of razors) {
+        const base = 0.12;
+        let score = base;
+        const hint = RAZOR_HINTS[id];
+        const description = RAZOR_DESCRIPTIONS[id] ?? hint?.label ?? `${id} razor`;
+        const label = hint?.label ?? `${id} Razor`;
+        const matches = hint?.signals?.filter((regex) => regex.test(text)) ?? [];
+        const reasons: string[] = [];
+
+        if (matches.length) {
+            score += matches.length * 0.18;
+            reasons.push(`Triggered by cues matching ${matches.map((m) => `/${m.source}/`).join(", ")}`);
+        }
+
+        if (hypotheses && (id === "MDL" || id === "BayesianOccam" || id === "Popper")) {
+            score += 0.22;
+            reasons.push("Hypothesis-oriented request benefits from parsimony and falsifiability checks");
+        }
+
+        if (creative && (id === "MDL" || id === "BayesianOccam" || id === "Sagan")) {
+            score += 0.18;
+            reasons.push("Divergent ideation needs trimming with simplicity/evidence tests");
+        }
+
+        if (risk && (id === "Sagan" || id === "Hitchens" || id === "Hanlon")) {
+            score += 0.15;
+            reasons.push("Risk/safety context favors evidence and intent discrimination razors");
+        }
+
+        if (constraint && id === "MDL") {
+            score += 0.12;
+            reasons.push("Constraint/optimization framing rewards minimal models");
+        }
+
+        if (explain && id === "Hitchens") {
+            score += 0.1;
+            reasons.push("Transparency demand highlights unsupported assertions");
+        }
+
+        if (code && id === "Popper") {
+            score += 0.08;
+            reasons.push("Executable experiments enable falsifiability checks");
+        }
+
+        if (score <= base + 0.01) {
+            reasons.push(description);
+        }
+
+        results.push({
+            id,
+            label,
+            score: clampScore(score),
+            reason: Array.from(new Set(reasons)).join("; "),
+        });
+    }
+
+    results.sort((a, b) => b.score - a.score);
+    return results.slice(0, 4);
+}
+
+export function registerSelector(server: McpServer): void {
+    const handler: ToolCallback<InputShape> = async ({ request, context, candidate_modes, candidate_razors }) => {
+        const modes = (candidate_modes?.length ? candidate_modes : [...MODE_IDS]).filter(isModeId);
+        const normalizedModes = modes.length ? modes : [...MODE_IDS];
+        const razorList = candidate_razors?.length ? candidate_razors : [...DEFAULT_RAZORS];
+
+        const prompt = `You are the ReasonSuite meta-selector. Analyze the user's request and recommend the single best reasoning mode to run next plus the razors to stack afterwards. Work through the cues explicitly and keep the output JSON strict.\n\nRequest: ${request}\nContext: ${context ?? "(none)"}\n\nCandidate thinking modes:\n${renderModeCatalog(normalizedModes)}\n\nCandidate razors:\n${renderRazorCatalog(razorList)}\n\nDeliberation instructions:\n1. Extract the salient signals or keywords from the request/context.\n2. Score each candidate mode between 0 and 1 using those signals.\n3. Pick the highest-utility primary_mode (prefer modes over razors unless the request explicitly centers razors).\n4. List up to three supporting modes with short justifications.\n5. Recommend up to four razors in the order they should be applied, or none if irrelevant.\n6. Document your reasoning steps as observation/implication pairs in decision_path.\n\nReturn strict JSON only:\n{\n  "primary_mode": {"id":"mode id","label":"human label","confidence":0.0-1.0,"reason":"summary"},\n  "supporting_modes": [{"id":"...","label":"...","score":0.0-1.0,"reason":"..."}],\n  "razor_stack": [{"id":"...","label":"...","score":0.0-1.0,"reason":"..."}],\n  "decision_path": [{"observation":"...","implication":"..."}],\n  "next_action": "optional guidance",\n  "notes": "optional caveats"\n}`;
+
+        const { text } = await sampleStructuredJson({
+            server,
+            prompt,
+            maxTokens: 750,
+            schema: OutputSchema,
+            fallback: () => buildFallback(request, context, normalizedModes, razorList),
+        });
+
+        return { content: [{ type: "text", text }] };
+    };
+
+    server.registerTool(
+        "reasoning.selector",
+        {
+            title: "Select reasoning mode & razors",
+            description:
+                "Given a request, recommend the most useful reasoning mode and which Occam/Popper-style razors to apply next.",
+            inputSchema: inputShape,
+        },
+        handler
+    );
+}

--- a/src/tools/self_explain.ts
+++ b/src/tools/self_explain.ts
@@ -1,19 +1,30 @@
-import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { McpServer, ToolCallback } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
+import type { ZodRawShape } from "zod";
+import { ReasoningMetadataSchema, sampleStructuredJson } from "../lib/structured.js";
+
+const InputSchema = z.object({
+    query: z.string(),
+    allow_citations: z.boolean().default(true),
+});
+
+const inputShape = InputSchema.shape as ZodRawShape;
+
+type InputArgs = z.output<typeof InputSchema>;
+type InputShape = typeof inputShape;
+
+const OutputSchema = z
+    .object({
+        rationale: z.array(z.string()).default([]),
+        evidence: z.array(z.object({ claim: z.string(), source: z.string().optional() })).default([]),
+        self_critique: z.array(z.string()).default([]),
+        revision: z.string(),
+    })
+    .extend({ meta: ReasoningMetadataSchema.optional() });
 
 export function registerSelfExplain(server: McpServer): void {
-    server.registerTool(
-        "reasoning.self_explain",
-        {
-            title: "Transparent Self-Explanation",
-            description: "Produce a rationale (chain-of-thought style summary), cite evidence, self-critique, and revise.",
-            inputSchema: {
-                query: z.string(),
-                allow_citations: z.boolean().default(true),
-            },
-        },
-        async ({ query, allow_citations }) => {
-            const prompt = `Transparent Self-Explanation.
+    const handler: ToolCallback<InputShape> = async ({ query, allow_citations }) => {
+        const prompt = `Transparent Self-Explanation.
 Query: ${query}
 
 Output strict JSON only:
@@ -24,25 +35,30 @@ Output strict JSON only:
   "revision": "final refined answer"
 }
 If citations allowed, include sources; otherwise, note what would be retrieved.`;
-            try {
-                const resp = await server.server.createMessage({
-                    messages: [{ role: "user", content: { type: "text", text: prompt } }],
-                    maxTokens: 900,
-                });
-                const out = resp.content.type === "text" ? resp.content.text : "{}";
-                return { content: [{ type: "text", text: out }] };
-            } catch {
-                const fallback = {
-                    rationale: ["analyze", "compare"],
-                    evidence: allow_citations ? [{ claim: "", source: "doc://razors.md" }] : [],
-                    self_critique: ["unclear assumptions"],
-                    revision: "draft",
-                };
-                return { content: [{ type: "text", text: JSON.stringify(fallback, null, 2) }] };
-            }
-        }
+        const { text } = await sampleStructuredJson({
+            server,
+            prompt,
+            maxTokens: 900,
+            schema: OutputSchema,
+            fallback: () => ({
+                rationale: ["Restate question", "Identify governing principles"],
+                evidence: allow_citations
+                    ? [{ claim: "Reference constraint DSL", source: "doc://constraint-dsl.md" }]
+                    : [{ claim: "Would cite constraint DSL guide if accessible" }],
+                self_critique: ["Assumes references remain current", "May miss domain-specific nuances"],
+                revision: "Deterministic fallback answer awaiting richer sampling.",
+            }),
+        });
+        return { content: [{ type: "text", text }] };
+    };
+
+    server.registerTool(
+        "reasoning.self_explain",
+        {
+            title: "Transparent Self-Explanation",
+            description: "Produce a rationale (chain-of-thought style summary), cite evidence, self-critique, and revise.",
+            inputSchema: inputShape,
+        },
+        handler
     );
 }
-
-
-

--- a/src/tools/socratic.ts
+++ b/src/tools/socratic.ts
@@ -1,21 +1,31 @@
-import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { McpServer, ToolCallback } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
+import type { ZodRawShape } from "zod";
+import { ReasoningMetadataSchema, sampleStructuredJson } from "../lib/structured.js";
+
+const InputSchema = z.object({
+    topic: z.string(),
+    context: z.string().optional(),
+    depth: z.number().int().min(1).max(6).default(3),
+});
+
+const inputShape = InputSchema.shape as ZodRawShape;
+
+type InputArgs = z.output<typeof InputSchema>;
+type InputShape = typeof inputShape;
+
+const OutputSchema = z
+    .object({
+        layers: z.array(z.object({ level: z.number().int(), questions: z.array(z.string()).default([]) })).default([]),
+        assumptions_to_test: z.array(z.string()).default([]),
+        evidence_to_collect: z.array(z.string()).default([]),
+        next_actions: z.array(z.string()).default([]),
+    })
+    .extend({ meta: ReasoningMetadataSchema.optional() });
 
 export function registerSocratic(server: McpServer): void {
-    server.registerTool(
-        "socratic.inquire",
-        {
-            title: "Socratic inquiry",
-            description:
-                "Generate a structured series of probing questions to clarify scope, assumptions, and evidence.",
-            inputSchema: {
-                topic: z.string(),
-                context: z.string().optional(),
-                depth: z.number().int().min(1).max(6).default(3),
-            },
-        },
-        async ({ topic, context, depth }) => {
-            const prompt = `Produce a ${depth}-layer Socratic question tree for: "${topic}"
+    const handler: ToolCallback<InputShape> = async ({ topic, context, depth }) => {
+        const prompt = `Produce a ${depth}-layer Socratic question tree for: "${topic}"
 Context: ${context ?? ""}
 Return strict JSON only:
 {
@@ -27,13 +37,40 @@ Return strict JSON only:
  "evidence_to_collect": ["..."],
  "next_actions": ["..."]
 }`;
-            const resp = await server.server.createMessage({
-                messages: [{ role: "user", content: { type: "text", text: prompt } }],
-                maxTokens: 600,
-            });
-            return { content: [{ type: "text", text: resp.content.type === "text" ? resp.content.text : "{}" }] };
-        }
+        const { text } = await sampleStructuredJson({
+            server,
+            prompt,
+            maxTokens: 600,
+            schema: OutputSchema,
+            fallback: () => {
+                const baseDepth = Math.min(Math.max(depth ?? 3, 1), 6);
+                return {
+                    layers: Array.from({ length: baseDepth }, (_, idx) => ({
+                        level: idx + 1,
+                        questions:
+                            idx === 0
+                                ? [
+                                      `What exactly counts as success for "${topic}"?`,
+                                      "Which stakeholders or constraints might we be missing?",
+                                  ]
+                                : ["What evidence would confirm or refute prior answers?"],
+                    })),
+                    assumptions_to_test: ["Clarify hidden premises", "Check context-specific caveats"],
+                    evidence_to_collect: ["Gather domain facts", "Consult primary stakeholders"],
+                    next_actions: ["Summarize answers", "Decide which reasoning tool to run next"],
+                };
+            },
+        });
+        return { content: [{ type: "text", text }] };
+    };
+
+    server.registerTool(
+        "socratic.inquire",
+        {
+            title: "Socratic inquiry",
+            description: "Generate a structured series of probing questions to clarify scope, assumptions, and evidence.",
+            inputSchema: inputShape,
+        },
+        handler
     );
 }
-
-

--- a/src/tools/systems.ts
+++ b/src/tools/systems.ts
@@ -1,17 +1,33 @@
-import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { McpServer, ToolCallback } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
+import type { ZodRawShape } from "zod";
+import { ReasoningMetadataSchema, sampleStructuredJson } from "../lib/structured.js";
+
+const InputSchema = z.object({
+    variables: z.array(z.string()).describe("Known variables").default([]),
+    context: z.string().optional(),
+});
+
+const inputShape = InputSchema.shape as ZodRawShape;
+
+type InputArgs = z.output<typeof InputSchema>;
+type InputShape = typeof inputShape;
+
+const OutputSchema = z
+    .object({
+        mermaid: z.string(),
+        loops: z.array(z.object({ type: z.enum(["reinforcing", "balancing"]), nodes: z.array(z.string()).default([]) })).default([]),
+        leverage_points: z.array(z.string()).default([]),
+        stock_flow_hints: z
+            .array(z.object({ stock: z.string(), inflows: z.array(z.string()).default([]), outflows: z.array(z.string()).default([]) }))
+            .default([]),
+        assumptions: z.array(z.string()).default([]),
+        risks: z.array(z.string()).default([]),
+    })
+    .extend({ meta: ReasoningMetadataSchema.optional() });
 
 export function registerSystems(server: McpServer): void {
-    const config = {
-        title: "Systems map (CLD)",
-        description:
-            "Create a causal loop diagram (Mermaid) with candidate reinforcing/balancing loops and leverage points.",
-        inputSchema: {
-            variables: z.array(z.string()).describe("Known variables").default([]),
-            context: z.string().optional(),
-        },
-    };
-    const handler = async ({ variables, context }: { variables: string[]; context?: string }) => {
+    const handler: ToolCallback<InputShape> = async ({ variables, context }) => {
         const prompt = `Build a concise causal loop diagram (CLD) for the system below.
 Variables: ${variables.join(", ") || "(discover reasonable variables)"}
 Context: ${context ?? ""}
@@ -25,14 +41,34 @@ Return strict JSON only:
  "assumptions":["..."],
  "risks":["..."]
 }`;
-        const resp = await server.server.createMessage({
-            messages: [{ role: "user", content: { type: "text", text: prompt } }],
+        const { text } = await sampleStructuredJson({
+            server,
+            prompt,
             maxTokens: 1000,
+            schema: OutputSchema,
+            fallback: () => ({
+                mermaid: "graph LR; need[Need]-->action[Action]; action-->outcome[Outcome]; outcome-->|feedback|need;",
+                loops: [
+                    { type: "reinforcing" as const, nodes: ["Need", "Action", "Outcome"] },
+                    { type: "balancing" as const, nodes: ["Outcome", "Constraints"] },
+                ],
+                leverage_points: ["Information flows", "Rules", "Goals"],
+                stock_flow_hints: [
+                    { stock: "Resource", inflows: ["Investment"], outflows: ["Consumption"] },
+                ],
+                assumptions: ["Variables listed capture dominant dynamics"],
+                risks: ["Hidden delays or non-linearities"],
+            }),
         });
-        return { content: [{ type: "text", text: resp.content.type === "text" ? resp.content.text : "{}" }] };
+        return { content: [{ type: "text", text }] };
     };
-    server.registerTool("systems.map", config as any, handler as any);
-    server.registerTool("systems_map", config as any, handler as any);
+
+    const config = {
+        title: "Systems map (CLD)",
+        description: "Create a causal loop diagram (Mermaid) with candidate reinforcing/balancing loops and leverage points.",
+        inputSchema: inputShape,
+    };
+
+    server.registerTool("systems.map", config, handler);
+    server.registerTool("systems_map", config, handler);
 }
-
-

--- a/src/types/node-shim.d.ts
+++ b/src/types/node-shim.d.ts
@@ -8,6 +8,13 @@ declare module "node:path" {
     export default anyExport;
 }
 
+declare module "node:http" {
+    export const createServer: any;
+}
+
+declare module "node:vm" {
+    export const Script: any;
+    export const createContext: any;
+}
+
 declare const process: any;
-
-


### PR DESCRIPTION
## Summary
- introduce a prompt-agnostic `reasoning.selector` MCP tool that scores available reasoning modes and razors with structured reasoning and heuristic fallback
- register the selector across the server entrypoint and smoke tests, expand lightweight node shims, and document the tool in the README
- adjust prompt argument typing to work with Zod v4 while keeping existing prompt helpers intact

## Testing
- `npm run build`
- `node dist/smoke.js`


------
https://chatgpt.com/codex/tasks/task_e_68d08e0b2e30832c98dd13957d78c9cb