### PR TITLE
Add direct LLM fallback when MCP sampling unavailable

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -1,9 +1,11 @@
+#!/usr/bin/env node
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
 import fs from "node:fs/promises";
 import { createServer } from "node:http";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 // Tools
 import { registerDialectic } from "./tools/dialectic.js";
 import { registerSocratic } from "./tools/socratic.js";
@@ -30,7 +32,8 @@ import { registerConstraintPrompts } from "./prompts/constraint.js";
 import { registerScientificPrompts } from "./prompts/scientific.js";
 import { registerSelfExplainPrompts } from "./prompts/self_explain.js";
 import { registerDivergentPrompts } from "./prompts/divergent.js";
-const server = new McpServer({ name: "reasonsuite", version: "1.0.0" });
+const pkgJson = JSON.parse(await fs.readFile(new URL("../package.json", import.meta.url), "utf-8"));
+const server = new McpServer({ name: pkgJson.name ?? "reasonsuite", version: pkgJson.version ?? "0.0.0" });
 // Register tools
 registerRouter(server);
 registerRazors(server);
@@ -57,8 +60,27 @@ registerConstraintPrompts(server);
 registerScientificPrompts(server);
 registerSelfExplainPrompts(server);
 registerDivergentPrompts(server);
+const moduleDir = fileURLToPath(new URL(".", import.meta.url));
+async function resolveResourcePath(file) {
+    const candidates = [
+        path.resolve(moduleDir, "resources", file),
+        path.resolve(moduleDir, "../resources", file),
+        path.resolve(moduleDir, "../src/resources", file),
+        path.resolve(process.cwd(), "src/resources", file),
+    ];
+    for (const candidate of candidates) {
+        try {
+            await fs.access(candidate);
+            return candidate;
+        }
+        catch {
+            // Continue trying other candidates
+        }
+    }
+    throw new Error(`Resource file not found: ${file}`);
+}
 async function addResource(file, title, description) {
-    const p = path.resolve(process.cwd(), "src/resources", file);
+    const p = await resolveResourcePath(file);
     server.registerResource(file, `doc://${file}`, { title, description, mimeType: "text/markdown" }, async (uri) => ({ contents: [{ uri: uri.href, text: await fs.readFile(p, "utf-8") }] }));
 }
 await addResource("razors.md", "Reasoning Razors", "Occam/MDL, Bayesian Occam, Sagan, Hitchens, Hanlon, Popper");

--- a/dist/lib/llm.js
+++ b/dist/lib/llm.js
@@ -1,0 +1,148 @@
+import http from "node:http";
+import https from "node:https";
+import { URL } from "node:url";
+function readEnv(name) {
+    const value = process.env[name];
+    if (!value) {
+        return undefined;
+    }
+    const trimmed = value.trim();
+    return trimmed.length > 0 ? trimmed : undefined;
+}
+function collectBody(res) {
+    return new Promise((resolve, reject) => {
+        const chunks = [];
+        res.on("data", (chunk) => {
+            chunks.push(typeof chunk === "string" ? Buffer.from(chunk) : chunk);
+        });
+        res.on("end", () => {
+            resolve(Buffer.concat(chunks).toString("utf-8"));
+        });
+        res.on("error", (err) => reject(err));
+    });
+}
+async function postJson(urlString, body, headers) {
+    const url = new URL(urlString);
+    const payload = JSON.stringify(body);
+    const isHttps = url.protocol === "https:";
+    const transport = isHttps ? https : http;
+    return new Promise((resolve, reject) => {
+        const req = transport.request({
+            protocol: url.protocol,
+            hostname: url.hostname,
+            port: url.port || (isHttps ? 443 : 80),
+            path: url.pathname + url.search,
+            method: "POST",
+            headers: {
+                "content-type": "application/json",
+                "content-length": Buffer.byteLength(payload).toString(),
+                ...headers,
+            },
+        }, async (res) => {
+            try {
+                const raw = await collectBody(res);
+                const status = res.statusCode ?? 0;
+                if (status < 200 || status >= 300) {
+                    reject(new Error(`HTTP ${status}: ${raw}`));
+                    return;
+                }
+                if (!raw) {
+                    resolve(undefined);
+                    return;
+                }
+                try {
+                    resolve(JSON.parse(raw));
+                }
+                catch (error) {
+                    reject(new Error(`Failed to parse JSON response: ${error?.message ?? String(error)}`));
+                }
+            }
+            catch (error) {
+                reject(error);
+            }
+        });
+        req.on("error", (err) => reject(err));
+        req.write(payload);
+        req.end();
+    });
+}
+async function callOpenAI(prompt, maxTokens) {
+    const apiKey = readEnv("OPENAI_API_KEY");
+    if (!apiKey) {
+        throw new Error("OPENAI_API_KEY not configured");
+    }
+    const model = readEnv("OPENAI_MODEL") ?? "gpt-4o-mini";
+    const temperature = Number(readEnv("OPENAI_TEMPERATURE") ?? "0.2");
+    const body = {
+        model,
+        messages: [{ role: "user", content: prompt }],
+        temperature: Number.isFinite(temperature) ? temperature : 0.2,
+        max_tokens: maxTokens,
+    };
+    const response = await postJson(readEnv("OPENAI_BASE_URL") ?? "https://api.openai.com/v1/chat/completions", body, {
+        Authorization: `Bearer ${apiKey}`,
+    });
+    const text = response?.choices?.[0]?.message?.content;
+    if (typeof text !== "string" || !text.trim()) {
+        throw new Error("OpenAI response did not include text content");
+    }
+    return { raw: text, provider: `openai:${model}` };
+}
+async function callAnthropic(prompt, maxTokens) {
+    const apiKey = readEnv("ANTHROPIC_API_KEY");
+    if (!apiKey) {
+        throw new Error("ANTHROPIC_API_KEY not configured");
+    }
+    const model = readEnv("ANTHROPIC_MODEL") ?? "claude-3-haiku-20240307";
+    const version = readEnv("ANTHROPIC_VERSION") ?? "2023-06-01";
+    const body = {
+        model,
+        max_tokens: maxTokens,
+        messages: [{ role: "user", content: prompt }],
+    };
+    const response = await postJson(readEnv("ANTHROPIC_BASE_URL") ?? "https://api.anthropic.com/v1/messages", body, {
+        "x-api-key": apiKey,
+        "anthropic-version": version,
+    });
+    const parts = Array.isArray(response?.content) ? response.content : [];
+    const text = parts
+        .map((part) => (typeof part?.text === "string" ? part.text : ""))
+        .filter((chunk) => chunk.length > 0)
+        .join("\n\n")
+        .trim();
+    if (!text) {
+        throw new Error("Anthropic response did not include text content");
+    }
+    return { raw: text, provider: `anthropic:${model}` };
+}
+export async function directLLMSample(prompt, maxTokens) {
+    const providers = [];
+    if (readEnv("OPENAI_API_KEY")) {
+        providers.push({ label: "openai", invoke: () => callOpenAI(prompt, maxTokens) });
+    }
+    if (readEnv("ANTHROPIC_API_KEY")) {
+        providers.push({ label: "anthropic", invoke: () => callAnthropic(prompt, maxTokens) });
+    }
+    if (providers.length === 0) {
+        return null;
+    }
+    const errors = [];
+    for (const { label, invoke } of providers) {
+        try {
+            const { raw, provider } = await invoke();
+            return {
+                success: true,
+                raw,
+                provider,
+                warnings: [`Used direct ${provider} fallback because MCP host sampling was unavailable.`],
+            };
+        }
+        catch (error) {
+            errors.push(`${label}: ${error?.message ?? String(error)}`);
+        }
+    }
+    return {
+        success: false,
+        reason: errors.join("; ") || "Direct LLM fallback failed",
+    };
+}

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "version": "1.0.1",
     "type": "module",
     "bin": {
-        "reasonsuite": "bin/reasonsuite"
+        "reasonsuite": "dist/index.js"
     },
     "scripts": {
         "build": "tsc -p tsconfig.json",

--- a/src/lib/llm.ts
+++ b/src/lib/llm.ts
@@ -1,0 +1,190 @@
+import http from "node:http";
+import https from "node:https";
+import { URL } from "node:url";
+
+type JsonHeaders = Record<string, string>;
+
+type JsonValue = Record<string, unknown> | undefined;
+
+type DirectProviderResult = {
+    raw: string;
+    provider: string;
+};
+
+type DirectProvider = () => Promise<DirectProviderResult>;
+
+type DirectSampleSuccess = {
+    success: true;
+    raw: string;
+    provider: string;
+    warnings: string[];
+};
+
+type DirectSampleFailure = {
+    success: false;
+    reason: string;
+};
+
+export type DirectSampleResult = DirectSampleSuccess | DirectSampleFailure;
+
+function readEnv(name: string): string | undefined {
+    const value = process.env[name];
+    if (!value) {
+        return undefined;
+    }
+    const trimmed = value.trim();
+    return trimmed.length > 0 ? trimmed : undefined;
+}
+
+function collectBody(res: http.IncomingMessage): Promise<string> {
+    return new Promise((resolve, reject) => {
+        const chunks: Buffer[] = [];
+        res.on("data", (chunk: Buffer | string) => {
+            chunks.push(typeof chunk === "string" ? Buffer.from(chunk) : chunk);
+        });
+        res.on("end", () => {
+            resolve(Buffer.concat(chunks).toString("utf-8"));
+        });
+        res.on("error", (err) => reject(err));
+    });
+}
+
+async function postJson(urlString: string, body: Record<string, unknown>, headers: JsonHeaders): Promise<JsonValue> {
+    const url = new URL(urlString);
+    const payload = JSON.stringify(body);
+    const isHttps = url.protocol === "https:";
+    const transport = isHttps ? https : http;
+
+    return new Promise((resolve, reject) => {
+        const req = transport.request(
+            {
+                protocol: url.protocol,
+                hostname: url.hostname,
+                port: url.port || (isHttps ? 443 : 80),
+                path: url.pathname + url.search,
+                method: "POST",
+                headers: {
+                    "content-type": "application/json",
+                    "content-length": Buffer.byteLength(payload).toString(),
+                    ...headers,
+                },
+            },
+            async (res) => {
+                try {
+                    const raw = await collectBody(res);
+                    const status = res.statusCode ?? 0;
+                    if (status < 200 || status >= 300) {
+                        reject(new Error(`HTTP ${status}: ${raw}`));
+                        return;
+                    }
+                    if (!raw) {
+                        resolve(undefined);
+                        return;
+                    }
+                    try {
+                        resolve(JSON.parse(raw));
+                    } catch (error: any) {
+                        reject(new Error(`Failed to parse JSON response: ${error?.message ?? String(error)}`));
+                    }
+                } catch (error) {
+                    reject(error);
+                }
+            }
+        );
+
+        req.on("error", (err) => reject(err));
+        req.write(payload);
+        req.end();
+    });
+}
+
+async function callOpenAI(prompt: string, maxTokens: number): Promise<DirectProviderResult> {
+    const apiKey = readEnv("OPENAI_API_KEY");
+    if (!apiKey) {
+        throw new Error("OPENAI_API_KEY not configured");
+    }
+    const model = readEnv("OPENAI_MODEL") ?? "gpt-4o-mini";
+    const temperature = Number(readEnv("OPENAI_TEMPERATURE") ?? "0.2");
+    const body = {
+        model,
+        messages: [{ role: "user", content: prompt }],
+        temperature: Number.isFinite(temperature) ? temperature : 0.2,
+        max_tokens: maxTokens,
+    };
+    const response = await postJson(
+        readEnv("OPENAI_BASE_URL") ?? "https://api.openai.com/v1/chat/completions",
+        body,
+        {
+            Authorization: `Bearer ${apiKey}`,
+        }
+    );
+    const text = (response as any)?.choices?.[0]?.message?.content;
+    if (typeof text !== "string" || !text.trim()) {
+        throw new Error("OpenAI response did not include text content");
+    }
+    return { raw: text, provider: `openai:${model}` };
+}
+
+async function callAnthropic(prompt: string, maxTokens: number): Promise<DirectProviderResult> {
+    const apiKey = readEnv("ANTHROPIC_API_KEY");
+    if (!apiKey) {
+        throw new Error("ANTHROPIC_API_KEY not configured");
+    }
+    const model = readEnv("ANTHROPIC_MODEL") ?? "claude-3-haiku-20240307";
+    const version = readEnv("ANTHROPIC_VERSION") ?? "2023-06-01";
+    const body = {
+        model,
+        max_tokens: maxTokens,
+        messages: [{ role: "user", content: prompt }],
+    };
+    const response = await postJson(readEnv("ANTHROPIC_BASE_URL") ?? "https://api.anthropic.com/v1/messages", body, {
+        "x-api-key": apiKey,
+        "anthropic-version": version,
+    });
+    const parts = Array.isArray((response as any)?.content) ? (response as any).content : [];
+    const text = parts
+        .map((part: any) => (typeof part?.text === "string" ? part.text : ""))
+        .filter((chunk: string) => chunk.length > 0)
+        .join("\n\n")
+        .trim();
+    if (!text) {
+        throw new Error("Anthropic response did not include text content");
+    }
+    return { raw: text, provider: `anthropic:${model}` };
+}
+
+export async function directLLMSample(prompt: string, maxTokens: number): Promise<DirectSampleResult | null> {
+    const providers: { label: string; invoke: DirectProvider }[] = [];
+
+    if (readEnv("OPENAI_API_KEY")) {
+        providers.push({ label: "openai", invoke: () => callOpenAI(prompt, maxTokens) });
+    }
+
+    if (readEnv("ANTHROPIC_API_KEY")) {
+        providers.push({ label: "anthropic", invoke: () => callAnthropic(prompt, maxTokens) });
+    }
+
+    if (providers.length === 0) {
+        return null;
+    }
+
+    const errors: string[] = [];
+    for (const { label, invoke } of providers) {
+        try {
+            const { raw, provider } = await invoke();
+            return {
+                success: true,
+                raw,
+                provider,
+                warnings: [`Used direct ${provider} fallback because MCP host sampling was unavailable.`],
+            };
+        } catch (error: any) {
+            errors.push(`${label}: ${error?.message ?? String(error)}`);
+        }
+    }
+
+    return {
+        success: false,
+        reason: errors.join("; ") || "Direct LLM fallback failed",
+    };
+}


### PR DESCRIPTION
## Summary
- ensure the CLI entry point resolves package metadata dynamically and exposes the built index as the npm binary
- add a portable resource path resolver so markdown resources load correctly when the server runs outside the repo
- include a shebang on the compiled entry point for direct execution
- add a direct OpenAI/Anthropic sampling fallback so tools can run when MCP hosts refuse LLM calls and expose clearer warnings

## Testing
- npm run build
- node dist/smoke.js
- node test_all_tools.js

------
https://chatgpt.com/codex/tasks/task_e_68d6e0d7e6d4832c92d96e1c5fc20a0d