### PR TITLE
Refactor ReasonSuite prompts for lower token usage

### DIFF
--- a/src/lib/llm.ts
+++ b/src/lib/llm.ts
@@ -200,7 +200,7 @@ async function callOpenRouter(prompt: string, maxTokens: number): Promise<Direct
     const headers: JsonHeaders = {
         "Authorization": `Bearer ${apiKey}`,
         "Content-Type": "application/json",
-        "HTTP-Referer": "https://github.com/your-repo/reasonsuite", // Replace with your actual repo
+        "HTTP-Referer": "https://github.com/henryhawke/ReasonSuite",
         "X-Title": "ReasonSuite",
     };
 

--- a/src/lib/mcp.ts
+++ b/src/lib/mcp.ts
@@ -10,12 +10,13 @@ export function textResult(text: string): CallToolResult {
     return { content: [textContent(text)] };
 }
 
-export function jsonResult(value: unknown): CallToolResult {
+export function jsonResult(value: unknown, { pretty = false }: { pretty?: boolean } = {}): CallToolResult {
     if (typeof value === "string") {
         return textResult(value);
     }
     try {
-        return textResult(JSON.stringify(value, null, 2));
+        const spacing = pretty ? 2 : undefined;
+        return textResult(JSON.stringify(value, null, spacing));
     } catch (error) {
         return textResult(String(value));
     }

--- a/src/lib/prompt.ts
+++ b/src/lib/prompt.ts
@@ -14,3 +14,73 @@ export const STRICT_JSON_REMINDER = [
     "- Use double quotes for every key and string literal.",
     "- Do not wrap the JSON in Markdown code fences or add commentary before or after it.",
 ].join("\n");
+
+export const STRICT_JSON_COMPACT =
+    "Output MUST be strict JSON that matches the schema. Double quotes for every key/string. No fences or commentary.";
+
+type PromptBuilderOptions = {
+    mode: string;
+    objective: string;
+    inputs: Record<string, string | undefined | null>;
+    steps: string[];
+    schema: string;
+    extras?: string[];
+    reminders?: string[];
+    maxInputLength?: number;
+};
+
+function formatValue(value: string | undefined | null, limit: number): string | null {
+    if (!value) {
+        return null;
+    }
+    const normalized = value.replace(/[\s\n\r\t]+/g, " ").trim();
+    if (!normalized) {
+        return null;
+    }
+    if (normalized.length <= limit) {
+        return normalized;
+    }
+    return `${normalized.slice(0, Math.max(0, limit - 1))}…`;
+}
+
+export function buildStructuredPrompt({
+    mode,
+    objective,
+    inputs,
+    steps,
+    schema,
+    extras = [],
+    reminders = [STRICT_JSON_COMPACT],
+    maxInputLength = 600,
+}: PromptBuilderOptions): string {
+    const sections: string[] = [];
+    sections.push(`${mode} mode.`);
+    sections.push(`Goal: ${objective}.`);
+
+    const formattedInputs = Object.entries(inputs)
+        .map(([key, value]) => {
+            const formatted = formatValue(value, maxInputLength);
+            return formatted ? `${key}: ${formatted}` : null;
+        })
+        .filter((entry): entry is string => typeof entry === "string");
+    if (formattedInputs.length) {
+        sections.push(`Inputs → ${formattedInputs.join(" | ")}`);
+    }
+
+    if (steps.length) {
+        const joinedSteps = steps.map((step, idx) => `${idx + 1}. ${step}`).join(" ");
+        sections.push(`Do → ${joinedSteps}`);
+    }
+
+    if (extras.length) {
+        sections.push(...extras.map((extra) => extra.trim()).filter(Boolean));
+    }
+
+    if (reminders.length) {
+        sections.push(...reminders.map((reminder) => reminder.trim()).filter(Boolean));
+    }
+
+    sections.push(`Schema → ${schema}`);
+
+    return sections.filter(Boolean).join("\n");
+}

--- a/src/prompts/abductive.ts
+++ b/src/prompts/abductive.ts
@@ -1,6 +1,6 @@
 import type { McpServer, PromptCallback } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
-import { definePromptArgsShape, STRICT_JSON_REMINDER } from "../lib/prompt.js";
+import { definePromptArgsShape, STRICT_JSON_COMPACT } from "../lib/prompt.js";
 
 const ArgsSchema = z.object({
     observations: z.string(),
@@ -19,7 +19,7 @@ export function registerAbductivePrompts(server: McpServer): void {
                     role: "user" as const,
                     content: {
                         type: "text" as const,
-                        text: `You are ReasonSuite's abductive reasoning engine.\n\nObservations:\n${observations}\n\nDeliberation steps:\n1. Extract the most telling clues or anomalies from the observations.\n2. Generate exactly ${target} labelled hypotheses (H1, H2, ...) that could explain the evidence.\n3. For each hypothesis provide a concise statement, a short rationale citing the clues, and 0-1 scores for prior_plausibility, explanatory_power, simplicity_penalty (penalize complexity), and testability.\n4. Compute overall = prior_plausibility + explanatory_power + testability - simplicity_penalty (round to two decimals).\n5. List discriminating experiments_or_evidence and capture any residual caveats in notes.\n${STRICT_JSON_REMINDER}\n\nJSON schema to emit:\n{"hypotheses":[{"id":"H1","statement":"...","rationale":"...","scores":{"prior_plausibility":0.0,"explanatory_power":0.0,"simplicity_penalty":0.0,"testability":0.0,"overall":0.0}}],"experiments_or_evidence":["..."],"notes":"..."}\nReturn only that JSON object.`,
+                        text: `You are ReasonSuite's abductive reasoning engine.\n\nObservations:\n${observations}\n\nDeliberation steps:\n1. Extract the most telling clues or anomalies from the observations.\n2. Generate exactly ${target} labelled hypotheses (H1, H2, ...) that could explain the evidence.\n3. For each hypothesis provide a concise statement, a short rationale citing the clues, and 0-1 scores for prior_plausibility, explanatory_power, simplicity_penalty (penalize complexity), and testability.\n4. Compute overall = prior_plausibility + explanatory_power + testability - simplicity_penalty (round to two decimals).\n5. List discriminating experiments_or_evidence and capture any residual caveats in notes.\n${STRICT_JSON_COMPACT}\n\nJSON schema to emit:\n{"hypotheses":[{"id":"H1","statement":"...","rationale":"...","scores":{"prior_plausibility":0.0,"explanatory_power":0.0,"simplicity_penalty":0.0,"testability":0.0,"overall":0.0}}],"experiments_or_evidence":["..."],"notes":"..."}\nReturn only that JSON object.`,
                     },
                 },
             ],

--- a/src/prompts/analogical.ts
+++ b/src/prompts/analogical.ts
@@ -1,6 +1,6 @@
 import type { McpServer, PromptCallback } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
-import { definePromptArgsShape, STRICT_JSON_REMINDER } from "../lib/prompt.js";
+import { definePromptArgsShape, STRICT_JSON_COMPACT } from "../lib/prompt.js";
 
 const ArgsSchema = z.object({
     source_domain: z.string(),
@@ -19,7 +19,7 @@ export function registerAnalogicalPrompts(server: McpServer): void {
                     role: "user" as const,
                     content: {
                         type: "text" as const,
-                        text: `Act as an analogy architect.\n\nSOURCE DOMAIN:\n${source_domain}\n\nTARGET PROBLEM:\n${target_problem}\n\nCONSTRAINTS OR MUST-HAVES:\n${constraints ?? "(none provided)"}\n\nDeliberation steps:\n1. Identify the core entities, relationships, and dynamics in the source domain.\n2. Map each relevant source element to the most plausible target counterpart and justify the mapping.\n3. List structural relations that transfer cleanly and flag mismatches or missing components that break the analogy.\n4. Summarize transferable_insights plus failure_modes or cautionary tales the target should watch.\n${STRICT_JSON_REMINDER}\n\nJSON schema to emit:\n{"mapping":[{"source":"...","target":"...","justification":"..."}],"shared_relations":["..."],"mismatches":["..."],"transferable_insights":["..."],"failure_modes":["..."]}\nReturn only that JSON object.`,
+                        text: `Act as an analogy architect.\n\nSOURCE DOMAIN:\n${source_domain}\n\nTARGET PROBLEM:\n${target_problem}\n\nCONSTRAINTS OR MUST-HAVES:\n${constraints ?? "(none provided)"}\n\nDeliberation steps:\n1. Identify the core entities, relationships, and dynamics in the source domain.\n2. Map each relevant source element to the most plausible target counterpart and justify the mapping.\n3. List structural relations that transfer cleanly and flag mismatches or missing components that break the analogy.\n4. Summarize transferable_insights plus failure_modes or cautionary tales the target should watch.\n${STRICT_JSON_COMPACT}\n\nJSON schema to emit:\n{"mapping":[{"source":"...","target":"...","justification":"..."}],"shared_relations":["..."],"mismatches":["..."],"transferable_insights":["..."],"failure_modes":["..."]}\nReturn only that JSON object.`,
                     },
                 },
             ],

--- a/src/prompts/constraint.ts
+++ b/src/prompts/constraint.ts
@@ -1,6 +1,6 @@
 import type { McpServer, PromptCallback } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
-import { definePromptArgsShape, STRICT_JSON_REMINDER } from "../lib/prompt.js";
+import { definePromptArgsShape, STRICT_JSON_COMPACT } from "../lib/prompt.js";
 
 const ArgsSchema = z.object({
     model_json: z.string(),
@@ -46,7 +46,7 @@ ${model_json}
    - unsatisfiable → {"status": "unsat", "model": {}}
    - unknown → {"status": "unknown", "model": {}}
 
-${STRICT_JSON_REMINDER}
+${STRICT_JSON_COMPACT}
 
 **Output Schema:**
 {"status": "sat|unsat|unknown", "model": {"var": "value"}}

--- a/src/prompts/dialectic.ts
+++ b/src/prompts/dialectic.ts
@@ -1,6 +1,6 @@
 import type { McpServer, PromptCallback } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
-import { definePromptArgsShape, STRICT_JSON_REMINDER } from "../lib/prompt.js";
+import { definePromptArgsShape, STRICT_JSON_COMPACT } from "../lib/prompt.js";
 
 const ArgsSchema = z.object({
     claim: z.string(),
@@ -18,7 +18,7 @@ export function registerDialecticPrompts(server: McpServer): void {
                     role: "user" as const,
                     content: {
                         type: "text" as const,
-                        text: `Apply a structured thesis–antithesis–synthesis analysis.\n\nClaim or proposal:\n${claim}\n\nContext or audience notes:\n${context ?? "(none)"}\n\nDeliberation steps:\n1. Summarise the strongest thesis supporting the claim with concrete key_points.\n2. Develop the strongest antithesis highlighting counterarguments, missing evidence, or risks.\n3. Craft a synthesis that reconciles or updates the claim, including proposal, assumptions, tradeoffs, and evidence_needed.\n4. List remaining open_questions that must be addressed.\n${STRICT_JSON_REMINDER}\n\nJSON schema to emit:\n{"thesis":{"position":"...","key_points":["..."]},"antithesis":{"position":"...","key_points":["..."]},"synthesis":{"proposal":"...","assumptions":["..."],"tradeoffs":["..."],"evidence_needed":["..."]},"open_questions":["..."]}\nReturn only that JSON object.`,
+                        text: `Apply a structured thesis–antithesis–synthesis analysis.\n\nClaim or proposal:\n${claim}\n\nContext or audience notes:\n${context ?? "(none)"}\n\nDeliberation steps:\n1. Summarise the strongest thesis supporting the claim with concrete key_points.\n2. Develop the strongest antithesis highlighting counterarguments, missing evidence, or risks.\n3. Craft a synthesis that reconciles or updates the claim, including proposal, assumptions, tradeoffs, and evidence_needed.\n4. List remaining open_questions that must be addressed.\n${STRICT_JSON_COMPACT}\n\nJSON schema to emit:\n{"thesis":{"position":"...","key_points":["..."]},"antithesis":{"position":"...","key_points":["..."]},"synthesis":{"proposal":"...","assumptions":["..."],"tradeoffs":["..."],"evidence_needed":["..."]},"open_questions":["..."]}\nReturn only that JSON object.`,
                     },
                 },
             ],

--- a/src/prompts/divergent.ts
+++ b/src/prompts/divergent.ts
@@ -1,6 +1,6 @@
 import type { McpServer, PromptCallback } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
-import { definePromptArgsShape, STRICT_JSON_REMINDER } from "../lib/prompt.js";
+import { definePromptArgsShape, STRICT_JSON_COMPACT } from "../lib/prompt.js";
 
 const ArgsSchema = z.object({
     prompt: z.string(),
@@ -21,7 +21,7 @@ export function registerDivergentPrompts(server: McpServer): void {
                     role: "user" as const,
                     content: {
                         type: "text" as const,
-                        text: `Run a divergent then convergent reasoning loop.\n\nProblem to explore:\n${prompt}\n\nNumber of initial ideas: ${ideaCount}\nScoring criteria (0-1): ${critList}\n\nDeliberation steps:\n1. Brainstorm ${ideaCount} distinct ideas or options related to the task (short bullet phrases are fine).\n2. Score each idea against every listed criterion between 0 and 1 with brief evaluator notes.\n3. Identify the winner and justify why it leads.\n4. Provide a synthesis that combines the best elements or next steps.\n${STRICT_JSON_REMINDER}\n\nJSON schema to emit:\n{"divergent":["idea1","idea2"],"scores":[{"id":1,"by":{"novelty":0.7,"consistency":0.6},"notes":"..."}],"winner":{"id":1,"why":"..."},"synthesis":"..."}\nReturn only that JSON object.`,
+                        text: `Run a divergent then convergent reasoning loop.\n\nProblem to explore:\n${prompt}\n\nNumber of initial ideas: ${ideaCount}\nScoring criteria (0-1): ${critList}\n\nDeliberation steps:\n1. Brainstorm ${ideaCount} distinct ideas or options related to the task (short bullet phrases are fine).\n2. Score each idea against every listed criterion between 0 and 1 with brief evaluator notes.\n3. Identify the winner and justify why it leads.\n4. Provide a synthesis that combines the best elements or next steps.\n${STRICT_JSON_COMPACT}\n\nJSON schema to emit:\n{"divergent":["idea1","idea2"],"scores":[{"id":1,"by":{"novelty":0.7,"consistency":0.6},"notes":"..."}],"winner":{"id":1,"why":"..."},"synthesis":"..."}\nReturn only that JSON object.`,
                     },
                 },
             ],

--- a/src/prompts/redblue.ts
+++ b/src/prompts/redblue.ts
@@ -1,6 +1,6 @@
 import type { McpServer, PromptCallback } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
-import { definePromptArgsShape, STRICT_JSON_REMINDER } from "../lib/prompt.js";
+import { definePromptArgsShape, STRICT_JSON_COMPACT } from "../lib/prompt.js";
 
 const ArgsSchema = z.object({
     proposal: z.string(),
@@ -21,7 +21,7 @@ export function registerRedBluePrompts(server: McpServer): void {
                     role: "user" as const,
                     content: {
                         type: "text" as const,
-                        text: `Run a structured red team vs blue team exercise.\n\nProposal under review:\n${proposal}\n\nNumber of rounds: ${roundCount}\nFocus areas: ${focusList}\n\nDeliberation steps:\n1. For each round capture red.attack (most concerning failure mode) then blue.defense (mitigations + mitigations list).\n2. Aggregate defects with type, severity (low|med|high), and supporting evidence.\n3. Populate a risk_matrix listing low/medium/high risks.\n4. Provide final_guidance actions or sign-off criteria.\n${STRICT_JSON_REMINDER}\n\nJSON schema to emit:\n{
+                        text: `Run a structured red team vs blue team exercise.\n\nProposal under review:\n${proposal}\n\nNumber of rounds: ${roundCount}\nFocus areas: ${focusList}\n\nDeliberation steps:\n1. For each round capture red.attack (most concerning failure mode) then blue.defense (mitigations + mitigations list).\n2. Aggregate defects with type, severity (low|med|high), and supporting evidence.\n3. Populate a risk_matrix listing low/medium/high risks.\n4. Provide final_guidance actions or sign-off criteria.\n${STRICT_JSON_COMPACT}\n\nJSON schema to emit:\n{
   "rounds": [
     {
       "n": 1,

--- a/src/prompts/scientific.ts
+++ b/src/prompts/scientific.ts
@@ -1,6 +1,6 @@
 import type { McpServer, PromptCallback } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
-import { definePromptArgsShape, STRICT_JSON_REMINDER } from "../lib/prompt.js";
+import { definePromptArgsShape, STRICT_JSON_COMPACT } from "../lib/prompt.js";
 
 const ArgsSchema = z.object({
     goal: z.string(),
@@ -20,7 +20,7 @@ export function registerScientificPrompts(server: McpServer): void {
                     role: "user" as const,
                     content: {
                         type: "text" as const,
-                        text: `Follow the ReasonSuite scientific analysis cadence.\n\nGoal:\n${goal}\n\nContext or known constraints:\n${context ?? "(none)"}\nTools allowed now? ${toolsFlag}\n\nDeliberation steps:\n1. Decomposition – break the goal into manageable sub-problems or questions.\n2. Hypotheses – list candidate explanations or solution directions to test.\n3. Tests – propose concrete experiments, code executions, constraint checks, or observations (prefer tool calls if allow_tools is true).\n4. Verification – describe how falsification or validation will occur (Popper style).\n5. Answer – deliver the best current conclusion with caveats.\n${STRICT_JSON_REMINDER}\n\nJSON schema to emit:\n{"decomposition":["..."],"hypotheses":["..."],"tests":["..."],"verification":{"strategy":"...","popper_falsification":"..."},"answer":"..."}\nReturn only that JSON object.`,
+                        text: `Follow the ReasonSuite scientific analysis cadence.\n\nGoal:\n${goal}\n\nContext or known constraints:\n${context ?? "(none)"}\nTools allowed now? ${toolsFlag}\n\nDeliberation steps:\n1. Decomposition – break the goal into manageable sub-problems or questions.\n2. Hypotheses – list candidate explanations or solution directions to test.\n3. Tests – propose concrete experiments, code executions, constraint checks, or observations (prefer tool calls if allow_tools is true).\n4. Verification – describe how falsification or validation will occur (Popper style).\n5. Answer – deliver the best current conclusion with caveats.\n${STRICT_JSON_COMPACT}\n\nJSON schema to emit:\n{"decomposition":["..."],"hypotheses":["..."],"tests":["..."],"verification":{"strategy":"...","popper_falsification":"..."},"answer":"..."}\nReturn only that JSON object.`,
                     },
                 },
             ],

--- a/src/prompts/self_explain.ts
+++ b/src/prompts/self_explain.ts
@@ -1,6 +1,6 @@
 import type { McpServer, PromptCallback } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
-import { definePromptArgsShape, STRICT_JSON_REMINDER } from "../lib/prompt.js";
+import { definePromptArgsShape, STRICT_JSON_COMPACT } from "../lib/prompt.js";
 
 const ArgsSchema = z.object({
     query: z.string(),
@@ -18,7 +18,7 @@ export function registerSelfExplainPrompts(server: McpServer): void {
                     role: "user" as const,
                     content: {
                         type: "text" as const,
-                        text: `Produce a transparent self-explanation.\n\nQuery or answer under review:\n${query}\nCitations allowed now? ${citeFlag}\n\nDeliberation steps:\n1. Draft a numbered rationale that walks through the reasoning at a high level.\n2. Provide evidence entries linking each claim to a citation or state "would retrieve" if citations are disallowed.\n3. List self_critique items highlighting weaknesses, missing data, or assumptions.\n4. Offer a concise revision that incorporates the critiques.\n${STRICT_JSON_REMINDER}\n\nJSON schema to emit:\n{"rationale":["..."],"evidence":[{"claim":"...","source":"..."}],"self_critique":["..."],"revision":"..."}\nReturn only that JSON object.`,
+                        text: `Produce a transparent self-explanation.\n\nQuery or answer under review:\n${query}\nCitations allowed now? ${citeFlag}\n\nDeliberation steps:\n1. Draft a numbered rationale that walks through the reasoning at a high level.\n2. Provide evidence entries linking each claim to a citation or state "would retrieve" if citations are disallowed.\n3. List self_critique items highlighting weaknesses, missing data, or assumptions.\n4. Offer a concise revision that incorporates the critiques.\n${STRICT_JSON_COMPACT}\n\nJSON schema to emit:\n{"rationale":["..."],"evidence":[{"claim":"...","source":"..."}],"self_critique":["..."],"revision":"..."}\nReturn only that JSON object.`,
                     },
                 },
             ],

--- a/src/prompts/socratic.ts
+++ b/src/prompts/socratic.ts
@@ -1,6 +1,6 @@
 import type { McpServer, PromptCallback } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
-import { definePromptArgsShape, STRICT_JSON_REMINDER } from "../lib/prompt.js";
+import { definePromptArgsShape, STRICT_JSON_COMPACT } from "../lib/prompt.js";
 
 const ArgsSchema = z.object({
     topic: z.string(),
@@ -52,7 +52,7 @@ ${topic}
    Example: "Interview 5 users about their workflow" ✅
    Not: "Learn more" ❌
 
-${STRICT_JSON_REMINDER}
+${STRICT_JSON_COMPACT}
 
 **Output Schema:**
 {

--- a/src/prompts/systems.ts
+++ b/src/prompts/systems.ts
@@ -1,6 +1,6 @@
 import type { McpServer, PromptCallback } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
-import { definePromptArgsShape, STRICT_JSON_REMINDER } from "../lib/prompt.js";
+import { definePromptArgsShape, STRICT_JSON_COMPACT } from "../lib/prompt.js";
 
 const ArgsSchema = z.object({
     variables: z.string().optional(),
@@ -18,7 +18,7 @@ export function registerSystemsPrompts(server: McpServer): void {
                     role: "user" as const,
                     content: {
                         type: "text" as const,
-                        text: `Construct a concise causal loop diagram (CLD).\n\nKnown variables or factors:\n${variables ?? "(discover relevant variables)"}\nContext:\n${context ?? "(no extra context)"}\n\nDeliberation steps:\n1. Draft a Mermaid graph string that captures the dominant feedback structure (use LR orientation).\n2. List reinforcing and balancing loops with node names in order.\n3. Identify leverage_points that could shift system behaviour.\n4. Provide stock_flow_hints describing stocks plus inflows/outflows.\n5. Record key assumptions and major risks or failure modes.\n${STRICT_JSON_REMINDER}\n\nJSON schema to emit:\n{"mermaid":"graph LR; ...","loops":[{"type":"reinforcing","nodes":["..."]}],"leverage_points":["..."],"stock_flow_hints":[{"stock":"...","inflows":["..."],"outflows":["..."]}],"assumptions":["..."],"risks":["..."]}\nReturn only that JSON object.`,
+                        text: `Construct a concise causal loop diagram (CLD).\n\nKnown variables or factors:\n${variables ?? "(discover relevant variables)"}\nContext:\n${context ?? "(no extra context)"}\n\nDeliberation steps:\n1. Draft a Mermaid graph string that captures the dominant feedback structure (use LR orientation).\n2. List reinforcing and balancing loops with node names in order.\n3. Identify leverage_points that could shift system behaviour.\n4. Provide stock_flow_hints describing stocks plus inflows/outflows.\n5. Record key assumptions and major risks or failure modes.\n${STRICT_JSON_COMPACT}\n\nJSON schema to emit:\n{"mermaid":"graph LR; ...","loops":[{"type":"reinforcing","nodes":["..."]}],"leverage_points":["..."],"stock_flow_hints":[{"stock":"...","inflows":["..."],"outflows":["..."]}],"assumptions":["..."],"risks":["..."]}\nReturn only that JSON object.`,
                     },
                 },
             ],

--- a/src/tools/dialectic.ts
+++ b/src/tools/dialectic.ts
@@ -1,7 +1,7 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
-import { textResult, type ToolCallback } from "../lib/mcp.js";
-import { STRICT_JSON_REMINDER } from "../lib/prompt.js";
+import { jsonResult, textResult, type ToolCallback } from "../lib/mcp.js";
+import { buildStructuredPrompt } from "../lib/prompt.js";
 import { ReasoningMetadataSchema, sampleStructuredJson } from "../lib/structured.js";
 
 const InputSchema = z.object({
@@ -31,32 +31,28 @@ const OutputSchema = z
 
 export function registerDialectic(server: McpServer): void {
     const handler: ToolCallback<any> = async (rawArgs, _extra) => {
-        const { claim, context, audience } = rawArgs as InputArgs;
-        const prompt = `Use a dialectical frame.
-Claim: ${claim}
-Context: ${context ?? ""}
-Audience: ${audience}
-
-Deliberation steps:
-1. Summarise the strongest thesis supporting the claim with concrete key_points.
-2. Develop the strongest antithesis highlighting counterarguments, missing evidence, or risks.
-3. Craft a synthesis that reconciles or updates the claim, including proposal, assumptions, tradeoffs, and evidence_needed.
-4. List remaining open_questions that must be addressed.
-
-${STRICT_JSON_REMINDER}
-
-JSON schema to emit:
-{
- "thesis": {"position": "...", "key_points": ["..."]},
- "antithesis": {"position": "...", "key_points": ["..."]},
-"synthesis": {"proposal": "...", "assumptions": ["..."], "tradeoffs": ["..."], "evidence_needed": ["..."]},
-"open_questions": ["..."]
-}
-Return only that JSON object.`;
+        const parsed = InputSchema.safeParse(rawArgs);
+        if (!parsed.success) {
+            return jsonResult({ error: "Invalid arguments for dialectic.tas", issues: parsed.error.issues });
+        }
+        const { claim, context, audience } = parsed.data;
+        const prompt = buildStructuredPrompt({
+            mode: "Dialectic",
+            objective: "Map the thesis, antithesis, and synthesis for the claim and audience.",
+            inputs: { claim, context, audience },
+            steps: [
+                "Thesis: strongest support plus concrete key_points.",
+                "Antithesis: strongest rebuttal, gaps, or risks.",
+                "Synthesis: reconciled proposal with assumptions, tradeoffs, evidence_needed.",
+                "Open_questions: remaining uncertainties to resolve.",
+            ],
+            schema:
+                '{"thesis":{"position":"","key_points":[]},"antithesis":{"position":"","key_points":[]},"synthesis":{"proposal":"","assumptions":[],"tradeoffs":[],"evidence_needed":[]},"open_questions":[]}',
+        });
         const { text } = await sampleStructuredJson({
             server,
             prompt,
-            maxTokens: 700,
+            maxTokens: 360,
             schema: OutputSchema,
             fallback: () => ({
                 thesis: {

--- a/src/tools/exec.ts
+++ b/src/tools/exec.ts
@@ -137,7 +137,11 @@ function runInSandbox(code: string, timeoutMs: number): ExecResult {
 
 export function registerExec(server: McpServer): void {
     const handler: ToolCallback<any> = async (rawArgs, _extra) => {
-        const { code, timeout_ms } = rawArgs as InputArgs;
+        const parsed = InputSchema.safeParse(rawArgs);
+        if (!parsed.success) {
+            return jsonResult({ error: "Invalid arguments for exec.run", issues: parsed.error.issues });
+        }
+        const { code, timeout_ms } = parsed.data;
         const result = runInSandbox(code, timeout_ms);
         const payload: ExecResult = {
             stdout: result.stdout,

--- a/src/tools/razors.ts
+++ b/src/tools/razors.ts
@@ -1,7 +1,7 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { jsonResult, textResult, type ToolCallback } from "../lib/mcp.js";
-import { STRICT_JSON_REMINDER } from "../lib/prompt.js";
+import { buildStructuredPrompt } from "../lib/prompt.js";
 import { DEFAULT_RAZORS, summarizeRazors } from "../lib/razors.js";
 import { ReasoningMetadataSchema, sampleStructuredJson } from "../lib/structured.js";
 
@@ -41,25 +41,24 @@ export function registerRazors(server: McpServer): void {
             const { candidates_json, razors: rawRazors } = parsed.data;
             const normalizedRazors = Array.isArray(rawRazors) ? rawRazors.filter((name): name is string => typeof name === "string") : undefined;
             const razors = normalizedRazors && normalizedRazors.length ? normalizedRazors : [...DEFAULT_RAZORS];
-            const prompt = `Candidates JSON:\n${candidates_json}
-Razors to apply (explain how each affects the verdict):
-${summarizeRazors(razors)}
-
-Deliberation steps:
-1. Parse the candidate entries from candidates_json.
-2. For each candidate, apply every listed razor and capture keep/drop/revise with reasons.
-3. Highlight notable risks or caveats in risk_notes.
-4. Build a shortlist of the strongest candidates and add any meta notes.
-
-${STRICT_JSON_REMINDER}
-
-JSON schema to emit:
-{ "results": [{"id":"...","keep_or_drop":"keep|drop|revise","reasons":["..."],"risk_notes":"..."}], "shortlist": ["ids..."], "notes": "..." }
-Return only that JSON object.`;
+            const prompt = buildStructuredPrompt({
+                mode: "Razor screening",
+                objective: "Evaluate each candidate and decide keep/drop/revise using the requested razors.",
+                inputs: { candidates_json, razors: razors.join(", ") },
+                steps: [
+                    "Parse candidate entries from candidates_json.",
+                    "Apply every razor to each candidate and set keep/drop/revise with reasons.",
+                    "Record notable risks or caveats in risk_notes.",
+                    "Build a shortlist of the strongest candidates and add any meta notes.",
+                ],
+                extras: [`Explain razor impact: ${summarizeRazors(razors)}`],
+                schema:
+                    '{"results":[{"id":"","keep_or_drop":"keep","reasons":[],"risk_notes":""}],"shortlist":[],"notes":""}',
+            });
             const { data } = await sampleStructuredJson({
                 server,
                 prompt,
-                maxTokens: 700,
+                maxTokens: 420,
                 schema: OutputSchema,
                 fallback: () => {
                     type CandidateShape = { id?: string; title?: string; name?: string } & Record<string, unknown>;


### PR DESCRIPTION
## Summary
- add a shared prompt builder with compact JSON instructions, input truncation, and token metadata to reduce prompt/response size
- update reasoning tools and router to use the builder with tighter token budgets, safer argument validation, and minified JSON output
- shorten prompt resources and fix the OpenRouter referer header for cleaner downstream usage

## Testing
- npm run build --silent

------
https://chatgpt.com/codex/tasks/task_e_68ecf3e74984832c8b38d6126312cf70