### PR TITLE
Add diagnostics tooling and server introspection

### DIFF
--- a/src/lib/server_state.ts
+++ b/src/lib/server_state.ts
@@ -1,0 +1,173 @@
+import fs from "node:fs/promises";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+
+type ToolMeta = {
+    name: string;
+    title?: string;
+    description?: string;
+    inputSchema?: unknown;
+};
+
+type PromptMeta = {
+    name: string;
+    title?: string;
+    description?: string;
+    argsSchema?: unknown;
+};
+
+type ResourceMeta = {
+    id: string;
+    uri?: string;
+    title?: string;
+    description?: string;
+    mimeType?: string;
+    path?: string;
+    status?: "ok" | "missing" | "unknown";
+    error?: string;
+};
+
+type ModeMeta = {
+    transport: string;
+    description: string;
+    localMode: boolean;
+};
+
+type Snapshot = {
+    startedAt: string;
+    uptimeMs: number;
+    tools: ToolMeta[];
+    prompts: PromptMeta[];
+    resources: ResourceMeta[];
+    counts: { tools: number; prompts: number; resources: number };
+    mode?: ModeMeta;
+    notes: string[];
+};
+
+type RecordResourceOptions = {
+    path?: string;
+    status?: ResourceMeta["status"];
+    error?: string;
+};
+
+export type ServerDiagnostics = {
+    snapshot(): Promise<Snapshot>;
+    setMode(meta: ModeMeta): void;
+    recordResource(id: string, options: RecordResourceOptions): void;
+};
+
+export function attachServerDiagnostics(server: McpServer): ServerDiagnostics {
+    const tools = new Map<string, ToolMeta>();
+    const prompts = new Map<string, PromptMeta>();
+    const resources = new Map<string, ResourceMeta>();
+    const startedAt = new Date();
+    let modeMeta: ModeMeta | undefined;
+
+    const patched = server as McpServer & {
+        registerTool: McpServer["registerTool"];
+        registerPrompt: McpServer["registerPrompt"];
+        registerResource: McpServer["registerResource"];
+    };
+
+    const originalRegisterTool = patched.registerTool.bind(server);
+    patched.registerTool = ((name: string, def: Parameters<McpServer["registerTool"]>[1], handler: any) => {
+        tools.set(name, {
+            name,
+            title: (def as any)?.title,
+            description: (def as any)?.description,
+            inputSchema: (def as any)?.inputSchema,
+        });
+        return originalRegisterTool(name, def as any, handler);
+    }) as McpServer["registerTool"];
+
+    const originalRegisterPrompt = patched.registerPrompt.bind(server);
+    patched.registerPrompt = ((name: string, def: Parameters<McpServer["registerPrompt"]>[1], handler: any) => {
+        prompts.set(name, {
+            name,
+            title: (def as any)?.title,
+            description: (def as any)?.description,
+            argsSchema: (def as any)?.argsSchema,
+        });
+        return originalRegisterPrompt(name, def as any, handler);
+    }) as McpServer["registerPrompt"];
+
+    const originalRegisterResource = patched.registerResource.bind(server);
+    patched.registerResource = ((...args: Parameters<McpServer["registerResource"]>) => {
+        const [name, uriOrTemplate, def] = args;
+        const entry = resources.get(name) ?? { id: name };
+        const metadata = def as { title?: string; description?: string; mimeType?: string };
+        resources.set(name, {
+            ...entry,
+            id: name,
+            uri: typeof uriOrTemplate === "string" ? uriOrTemplate : entry.uri,
+            title: metadata?.title ?? entry.title,
+            description: metadata?.description ?? entry.description,
+            mimeType: metadata?.mimeType ?? entry.mimeType,
+        });
+        return originalRegisterResource(...(args as Parameters<McpServer["registerResource"]>));
+    }) as McpServer["registerResource"];
+
+    const recordResource = (id: string, options: RecordResourceOptions) => {
+        const existing = resources.get(id) ?? { id };
+        resources.set(id, {
+            ...existing,
+            ...options,
+        });
+    };
+
+    const snapshot = async (): Promise<Snapshot> => {
+        const uptimeMs = Date.now() - startedAt.getTime();
+        const notes: string[] = [];
+
+        const resourceList = await Promise.all(
+            Array.from(resources.values())
+                .sort((a, b) => a.id.localeCompare(b.id))
+                .map(async (entry) => {
+                    const next = { ...entry } satisfies ResourceMeta;
+                    if (next.path && next.status !== "missing") {
+                        try {
+                            await fs.access(next.path);
+                            next.status = "ok";
+                            next.error = undefined;
+                        } catch (error) {
+                            next.status = "missing";
+                            next.error = (error as Error)?.message ?? String(error);
+                        }
+                    } else if (!next.status) {
+                        next.status = next.path ? "unknown" : "missing";
+                    }
+                    return next;
+                })
+        );
+
+        const missingResources = resourceList.filter((entry) => entry.status === "missing");
+        if (missingResources.length > 0) {
+            notes.push(
+                `Missing ${missingResources.length} resource(s): ${missingResources.map((r) => r.id).join(", ")}. ` +
+                    "Set REASONSUITE_RESOURCES to include the directory containing the markdown files."
+            );
+        }
+
+        if (!modeMeta) {
+            notes.push("Transport mode not initialised; server may not have connected yet.");
+        }
+
+        return {
+            startedAt: startedAt.toISOString(),
+            uptimeMs,
+            tools: Array.from(tools.values()).sort((a, b) => a.name.localeCompare(b.name)),
+            prompts: Array.from(prompts.values()).sort((a, b) => a.name.localeCompare(b.name)),
+            resources: resourceList,
+            counts: { tools: tools.size, prompts: prompts.size, resources: resources.size },
+            mode: modeMeta,
+            notes,
+        } satisfies Snapshot;
+    };
+
+    return {
+        snapshot,
+        setMode(meta: ModeMeta) {
+            modeMeta = meta;
+        },
+        recordResource,
+    } satisfies ServerDiagnostics;
+}

--- a/src/router/router.ts
+++ b/src/router/router.ts
@@ -7,6 +7,7 @@ import { DEFAULT_RAZORS } from "../lib/razors.js";
 import { ReasoningMetadataSchema, sampleStructuredJson } from "../lib/structured.js";
 import { buildFallback as selectorFallback } from "../tools/selector.js";
 import type { RouterPlan, RouterStep } from "../lib/types.js";
+import { SIGNAL_DESCRIPTIONS, type RouterSignals } from "./signals.js";
 
 const ModeSchema = z.enum([
     "socratic",
@@ -125,34 +126,6 @@ const inputShape = InputSchema.shape;
 
 type InputArgs = z.output<typeof InputSchema>;
 type InputShape = typeof inputShape;
-
-type RouterSignals = {
-    needsHypotheses: boolean;
-    needsCreative: boolean;
-    needsSystems: boolean;
-    needsConstraint: boolean;
-    needsRisk: boolean;
-    contested: boolean;
-    wantsAnalogy: boolean;
-    needsScientific: boolean;
-    wantsSelfExplain: boolean;
-    codeOrCalc: boolean;
-    deepScope: boolean;
-};
-
-const SIGNAL_DESCRIPTIONS: Record<keyof RouterSignals, string> = {
-    needsHypotheses: "Diagnosis / uncertainty cues detected → schedule abductive.hypothesize to explore explanations.",
-    needsCreative: "Creative or brainstorming language detected → add reasoning.divergent_convergent for option generation.",
-    needsSystems: "Systemic / feedback terminology detected → include systems.map to surface loops and leverage points.",
-    needsConstraint: "Constraint or optimisation keywords detected → include constraint.solve for feasibility checking.",
-    needsRisk: "Risk, safety, or abuse terms detected → run redblue.challenge before finalising outcomes.",
-    contested: "Controversy or trade-off language detected → use dialectic.tas to examine opposing positions.",
-    wantsAnalogy: "Analogy or comparison cues detected → include analogical.map to transfer structure carefully.",
-    needsScientific: "Experiment / evidence requests detected → include reasoning.scientific for test planning.",
-    wantsSelfExplain: "Transparency / rationale requests detected → finish with reasoning.self_explain.",
-    codeOrCalc: "Code or computation keywords detected → schedule exec.run for sandboxed verification.",
-    deepScope: "Complex strategy / roadmap wording detected → use a deeper socratic.inquire depth setting.",
-};
 
 export function registerRouter(server: McpServer): void {
     const handler: ToolCallback<any> = async (rawArgs, _extra) => {

--- a/src/router/signals.ts
+++ b/src/router/signals.ts
@@ -1,0 +1,27 @@
+export type RouterSignals = {
+    needsHypotheses: boolean;
+    needsCreative: boolean;
+    needsSystems: boolean;
+    needsConstraint: boolean;
+    needsRisk: boolean;
+    contested: boolean;
+    wantsAnalogy: boolean;
+    needsScientific: boolean;
+    wantsSelfExplain: boolean;
+    codeOrCalc: boolean;
+    deepScope: boolean;
+};
+
+export const SIGNAL_DESCRIPTIONS: Record<keyof RouterSignals, string> = {
+    needsHypotheses: "Diagnosis / uncertainty cues detected → schedule abductive.hypothesize to explore explanations.",
+    needsCreative: "Creative or brainstorming language detected → add reasoning.divergent_convergent for option generation.",
+    needsSystems: "Systemic / feedback terminology detected → include systems.map to surface loops and leverage points.",
+    needsConstraint: "Constraint or optimisation keywords detected → include constraint.solve for feasibility checking.",
+    needsRisk: "Risk, safety, or abuse terms detected → run redblue.challenge before finalising outcomes.",
+    contested: "Controversy or trade-off language detected → use dialectic.tas to examine opposing positions.",
+    wantsAnalogy: "Analogy or comparison cues detected → include analogical.map to transfer structure carefully.",
+    needsScientific: "Experiment / evidence requests detected → include reasoning.scientific for test planning.",
+    wantsSelfExplain: "Transparency / rationale requests detected → finish with reasoning.self_explain.",
+    codeOrCalc: "Code or computation keywords detected → schedule exec.run for sandboxed verification.",
+    deepScope: "Complex strategy / roadmap wording detected → use a deeper socratic.inquire depth setting.",
+};

--- a/src/tools/diagnostics.ts
+++ b/src/tools/diagnostics.ts
@@ -1,0 +1,154 @@
+import os from "node:os";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import { jsonResult, type ToolCallback } from "../lib/mcp.js";
+import { normalizeToolInput } from "../lib/args.js";
+import { DEFAULT_RAZORS } from "../lib/razors.js";
+import { SIGNAL_DESCRIPTIONS } from "../router/signals.js";
+import type { ServerDiagnostics } from "../lib/server_state.js";
+
+type Identity = {
+    name: string;
+    version: string;
+};
+
+const InputSchema = z
+    .object({
+        detail: z.enum(["summary", "full"]).default("full"),
+        pretty: z.boolean().default(false),
+        include_router_signals: z.boolean().default(true),
+    })
+    .partial({ pretty: true, include_router_signals: true });
+
+const inputSchema = InputSchema.shape;
+
+type InputArgs = z.output<typeof InputSchema>;
+
+type DiagnosticsPayload = {
+    status: "ok" | "warn";
+    generated_at: string;
+    server: {
+        name: string;
+        version: string;
+        mode?: {
+            transport: string;
+            description: string;
+            localMode: boolean;
+        };
+        started_at: string;
+        uptime_ms: number;
+    };
+    counts: {
+        tools: number;
+        prompts: number;
+        resources: number;
+    };
+    environment: {
+        node: string;
+        platform: string;
+        pid: number;
+        release: string;
+        cpus: number;
+    };
+    notes: string[];
+    tools?: Array<{
+        name: string;
+        title?: string;
+        description?: string;
+        has_schema: boolean;
+    }>;
+    prompts?: Array<{
+        name: string;
+        title?: string;
+        description?: string;
+        has_args: boolean;
+    }>;
+    resources?: Array<{
+        id: string;
+        title?: string;
+        description?: string;
+        uri?: string;
+        path?: string;
+        status?: string;
+        error?: string;
+    }>;
+    heuristics?: {
+        default_razors: string[];
+        router_signals?: Record<string, string>;
+    };
+};
+
+export function registerDiagnostics(server: McpServer, diagnostics: ServerDiagnostics, identity: Identity): void {
+    const handler: ToolCallback<any> = async (rawArgs, _extra) => {
+        const parsed = InputSchema.safeParse(normalizeToolInput(rawArgs));
+        if (!parsed.success) {
+            return jsonResult({ error: "Invalid arguments for reasoning.diagnostics", issues: parsed.error.issues });
+        }
+
+        const { detail, pretty, include_router_signals } = parsed.data as InputArgs;
+        const snapshot = await diagnostics.snapshot();
+
+        const payload: DiagnosticsPayload = {
+            status: snapshot.notes.length ? "warn" : "ok",
+            generated_at: new Date().toISOString(),
+            server: {
+                name: identity.name,
+                version: identity.version,
+                mode: snapshot.mode,
+                started_at: snapshot.startedAt,
+                uptime_ms: snapshot.uptimeMs,
+            },
+            counts: snapshot.counts,
+            environment: {
+                node: process.version,
+                platform: `${process.platform}-${process.arch}`,
+                pid: process.pid,
+                release: os.release(),
+                cpus: os.cpus().length,
+            },
+            notes: snapshot.notes,
+        };
+
+        if (detail === "full") {
+            payload.tools = snapshot.tools.map((tool) => ({
+                name: tool.name,
+                title: tool.title,
+                description: tool.description,
+                has_schema: Boolean(tool.inputSchema),
+            }));
+            payload.prompts = snapshot.prompts.map((prompt) => ({
+                name: prompt.name,
+                title: prompt.title,
+                description: prompt.description,
+                has_args: Boolean(prompt.argsSchema),
+            }));
+            payload.resources = snapshot.resources.map((resource) => ({
+                id: resource.id,
+                title: resource.title,
+                description: resource.description,
+                uri: resource.uri,
+                path: resource.path,
+                status: resource.status,
+                error: resource.error,
+            }));
+        }
+
+        payload.heuristics = {
+            default_razors: [...DEFAULT_RAZORS],
+            router_signals: include_router_signals ? { ...SIGNAL_DESCRIPTIONS } : undefined,
+        };
+
+        return jsonResult(payload, { pretty });
+    };
+
+    server.registerTool(
+        "reasoning.diagnostics",
+        {
+            title: "ReasonSuite diagnostics",
+            description:
+                "Summarise server status, environment, registered tools/prompts/resources, and key heuristic stacks.",
+            inputSchema,
+        },
+        handler
+    );
+}

--- a/test_all_tools.js
+++ b/test_all_tools.js
@@ -15,6 +15,8 @@ import { registerDivergent } from "./dist/tools/divergent.js";
 import { registerExec } from "./dist/tools/exec.js";
 import { registerSelector } from "./dist/tools/selector.js";
 import { registerReasoning } from "./dist/tools/reasoning.js";
+import { registerDiagnostics } from "./dist/tools/diagnostics.js";
+import { attachServerDiagnostics } from "./dist/lib/server_state.js";
 
 class TestHarnessServer {
   tools = new Map();
@@ -198,6 +200,7 @@ function parseResult(res) {
 
 async function run() {
   const server = new TestHarnessServer();
+  const diagnostics = attachServerDiagnostics(server);
 
   // Register all tools
   registerRouter(server);
@@ -215,6 +218,8 @@ async function run() {
   registerExec(server);
   registerSelector(server);
   registerReasoning(server);
+  registerDiagnostics(server, diagnostics, { name: "reasonsuite", version: "test" });
+  diagnostics.setMode({ transport: "stdio", description: "Test harness", localMode: true });
 
   const out = [];
   const call = async (name, args) => {
@@ -234,6 +239,8 @@ async function run() {
     request: "Investigate root cause of intermittent failure",
     context: "timeouts, spike at 02:00 UTC",
   });
+
+  await call("reasoning.diagnostics", { detail: "summary" });
 
   // Dialectic (aliases)
   await call("dialectic.tas", {


### PR DESCRIPTION
## Summary
- add a diagnostics tool and supporting server introspection state tracking
- make resource loading resilient to missing files and expose override via REASONSUITE_RESOURCES
- surface router signal metadata for reuse and extend the tool harness to cover diagnostics

## Testing
- npm run build
- node test_all_tools.js

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691748e44674832cb0b74f9776cc987e)